### PR TITLE
[ijehyunpark] step-3 체스판 초기화

### DIFF
--- a/src/main/java/softeer2nd/Main.java
+++ b/src/main/java/softeer2nd/Main.java
@@ -1,7 +1,29 @@
 package softeer2nd;
 
+import softeer2nd.chess.Board;
+
+import java.util.Scanner;
+
 public class Main {
     public static void main(String[] args) {
-        System.out.println("Hello world!");
+        Scanner scanner = new Scanner(System.in);
+
+        boolean scanLoop = true;
+        while(scanLoop) {
+            // 명령어 입력
+            String command = scanner.nextLine();
+            Board board;
+
+            switch (command) {
+                case "start":
+                    board = new Board();
+                    board.initialize();
+                    System.out.println(board.print());
+                    break;
+                case "end":
+                    scanLoop = false;
+                    break;
+            }
+        }
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -4,13 +4,23 @@ import softeer2nd.chess.pieces.Pawn;
 import softeer2nd.chess.pieces.Token;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 체스 보드판을 나타낸다.
  */
 public class Board {
+    public static final int COLUMN_NUMBER = 8;
+    public static final int ROW_NUMBER = 8;
+    public static final int INIT_PAWN_NUMBER = 8;
     private final List<Token> tokens = new ArrayList<>();
+    private int[][] tokenPosition = new int[COLUMN_NUMBER][ROW_NUMBER];
+
+    public Board() {
+        Arrays.stream(tokenPosition).forEach(column -> Arrays.fill(column, -1));
+    }
 
     /**
      * 체스 보드판에 새로운 게임 말을 추가한다.
@@ -42,5 +52,32 @@ public class Board {
             return (Pawn) target;
 
         throw new IllegalArgumentException("폰 객체가 아닙니다.");
+    }
+
+    /**
+     * 체스 보드판을 초기화한다.
+     */
+    public void initialize() {
+        // 흰색, 검은색 폰을 초기 개수만큼 할당한다.
+        for (int i = 0; i < INIT_PAWN_NUMBER; i++) {
+            tokens.add(new Pawn(Color.BLACK));
+            tokens.add(new Pawn(Color.WHITE));
+        }
+
+        for (int i = 0; i < ROW_NUMBER; i++) {
+            tokenPosition[1][i] = i * 2;
+            tokenPosition[6][i] = i * 2 + 1;
+        }
+    }
+
+    /**
+     * 해당 보드판 위치에 존재하는 게임 말을 찾는다.
+     * @param column 보드판 세로 좌표
+     * @param row 보드판 가로 좌표
+     * @return 만약 해당 보드판 위치에 게임말이 존재할 경우 해당 게임말을 반환한다. 없는 경우 null을 반환한다.
+     */
+    public Optional<Token> getTokenByPosition(int column, int row) {
+        Token result = tokenPosition[column][row] == -1 ? null : tokens.get(tokenPosition[column][row]);
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -81,4 +81,20 @@ public class Board {
         Token result = tokenPosition[column][row] == -1 ? null : tokens.get(tokenPosition[column][row]);
         return Optional.ofNullable(result);
     }
+
+    /**
+     * 현재 체스 보드판의 상태를 문자열로 변환한다.
+     * @return 현재 체스 보드판의 상태를 나타내는 문자열
+     */
+    public String print() {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < COLUMN_NUMBER; i++) {
+            for (int j = 0; j < ROW_NUMBER; j++) {
+                Optional<Token> token = getTokenByPosition(i, j);
+                builder.append(token.map(Token::getRepresentation).orElse('.'));
+            }
+            builder.append('\n');
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -16,7 +16,7 @@ public class Board {
     public static final int ROW_NUMBER = 8;
     public static final int INIT_PAWN_NUMBER = 8;
     private final List<Token> tokens = new ArrayList<>();
-    private int[][] tokenPosition = new int[COLUMN_NUMBER][ROW_NUMBER];
+    private final int[][] tokenPosition = new int[COLUMN_NUMBER][ROW_NUMBER];
 
     public Board() {
         Arrays.stream(tokenPosition).forEach(column -> Arrays.fill(column, -1));
@@ -24,11 +24,17 @@ public class Board {
 
     /**
      * 체스 보드판에 새로운 게임 말을 추가한다.
-     * @param token 추가할 새로운 게임 말(폰만 허용)
+     * @param token 추가할 새로운 게임 말
+     * @param column 추가할 새로운 게임 말의 세로축 위치
+     * @param row 추가할 새로운 게임 말의 가로축 위치
      */
-    public void add(Token token) {
+    public void add(Token token, int column, int row) {
+        if(tokenPosition[column][row] != -1)
+            throw new IllegalArgumentException("이미 다른 게임 말이 존재하는 위치입니다.");
         this.tokens.add(token);
+        this.tokenPosition[column][row] = this.size() - 1;
     }
+
 
     /**
      * 현재 체스 보드판에 존재하는 게임 말의 개수를 찾는다.
@@ -60,13 +66,8 @@ public class Board {
     public void initialize() {
         // 흰색, 검은색 폰을 초기 개수만큼 할당한다.
         for (int i = 0; i < INIT_PAWN_NUMBER; i++) {
-            tokens.add(new Pawn(Color.BLACK));
-            tokens.add(new Pawn(Color.WHITE));
-        }
-
-        for (int i = 0; i < ROW_NUMBER; i++) {
-            tokenPosition[1][i] = i * 2;
-            tokenPosition[6][i] = i * 2 + 1;
+            add(new Pawn(Color.BLACK), 1, i);
+            add(new Pawn(Color.WHITE), 6, i);
         }
     }
 

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -1,7 +1,7 @@
 package softeer2nd.chess;
 
 import softeer2nd.chess.pieces.Pawn;
-import softeer2nd.chess.pieces.Token;
+import softeer2nd.chess.pieces.Piece;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,20 +15,20 @@ public class Board {
     public static final int COLUMN_NUMBER = 8;
     public static final int ROW_NUMBER = 8;
     public static final int INIT_PAWN_NUMBER = 8;
-    private final List<Token> tokens = new ArrayList<>();
-    private final int[][] tokenPosition = new int[COLUMN_NUMBER][ROW_NUMBER];
+    private final List<Piece> pieces = new ArrayList<>();
+    private final int[][] piecePosition = new int[COLUMN_NUMBER][ROW_NUMBER];
 
     /**
      * 체스 보드판에 새로운 게임 말을 추가한다.
-     * @param token 추가할 새로운 게임 말
+     * @param piece 추가할 새로운 게임 말
      * @param column 추가할 새로운 게임 말의 세로축 위치
      * @param row 추가할 새로운 게임 말의 가로축 위치
      */
-    public void add(Token token, int column, int row) {
-        if(tokenPosition[column][row] != -1)
+    public void add(Piece piece, int column, int row) {
+        if(piecePosition[column][row] != -1)
             throw new IllegalArgumentException("이미 다른 게임 말이 존재하는 위치입니다.");
-        this.tokens.add(token);
-        this.tokenPosition[column][row] = this.size() - 1;
+        this.pieces.add(piece);
+        this.piecePosition[column][row] = this.size() - 1;
     }
 
 
@@ -37,7 +37,7 @@ public class Board {
      * @return 체스 보드판 내의 게임 말 개수
      */
     public int size() {
-        return tokens.size();
+        return pieces.size();
     }
 
     /**
@@ -46,10 +46,10 @@ public class Board {
      * @return 만약, 게임 말이 존재할 경우 해당 게임말을 반환한다. 없을 경우 null을 반환하다.
      */
     public Pawn findPawn(int i) {
-        if(this.tokens.size() <= i || i < 0)
+        if(this.pieces.size() <= i || i < 0)
             throw new IllegalArgumentException("잘못된 인덱스 접근입니다.");
 
-        Token target = this.tokens.get(i);
+        Piece target = this.pieces.get(i);
         if(target.isPawn())
             return (Pawn) target;
 
@@ -61,9 +61,9 @@ public class Board {
      */
     public void initialize() {
         // 할당된 토큰을 모두 삭제한다.
-        tokens.clear();
+        pieces.clear();
         // 토큰의 위치 정보를 제거한다.
-        Arrays.stream(tokenPosition).forEach(column -> Arrays.fill(column, -1));
+        Arrays.stream(piecePosition).forEach(column -> Arrays.fill(column, -1));
 
         // 흰색, 검은색 폰을 초기 개수만큼 할당한다.
         for (int i = 0; i < INIT_PAWN_NUMBER; i++) {
@@ -78,8 +78,8 @@ public class Board {
      * @param row 보드판 가로 좌표
      * @return 만약 해당 보드판 위치에 게임말이 존재할 경우 해당 게임말을 반환한다. 없는 경우 null을 반환한다.
      */
-    public Optional<Token> getTokenByPosition(int column, int row) {
-        Token result = tokenPosition[column][row] == -1 ? null : tokens.get(tokenPosition[column][row]);
+    public Optional<Piece> getPieceByPosition(int column, int row) {
+        Piece result = piecePosition[column][row] == -1 ? null : pieces.get(piecePosition[column][row]);
         return Optional.ofNullable(result);
     }
 
@@ -91,8 +91,8 @@ public class Board {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < COLUMN_NUMBER; i++) {
             for (int j = 0; j < ROW_NUMBER; j++) {
-                Optional<Token> token = getTokenByPosition(i, j);
-                builder.append(token.map(Token::getRepresentation).orElse('.'));
+                Optional<Piece> piece = getPieceByPosition(i, j);
+                builder.append(piece.map(Piece::getRepresentation).orElse('.'));
             }
             builder.append('\n');
         }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -2,6 +2,7 @@ package softeer2nd.chess;
 
 import softeer2nd.chess.pieces.Pawn;
 import softeer2nd.chess.pieces.Piece;
+import softeer2nd.chess.pieces.PieceType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,26 +51,39 @@ public class Board {
             throw new IllegalArgumentException("잘못된 인덱스 접근입니다.");
 
         Piece target = this.pieces.get(i);
-        if(target.isPawn())
+        if(target.getPieceType() == PieceType.Pawn)
             return (Pawn) target;
 
         throw new IllegalArgumentException("폰 객체가 아닙니다.");
     }
 
     /**
-     * 체스 보드판을 초기화한다.
+     * 토큰 정보를 초기화한다.
      */
-    public void initialize() {
+    public void clear() {
         // 할당된 토큰을 모두 삭제한다.
         pieces.clear();
         // 토큰의 위치 정보를 제거한다.
         Arrays.stream(piecePosition).forEach(column -> Arrays.fill(column, -1));
+    }
 
+    /**
+     * 초기 폰 객체를 배치한다.
+     */
+    public void initPawn() {
         // 흰색, 검은색 폰을 초기 개수만큼 할당한다.
         for (int i = 0; i < INIT_PAWN_NUMBER; i++) {
             add(new Pawn(Color.BLACK), 1, i);
             add(new Pawn(Color.WHITE), 6, i);
         }
+    }
+
+    /**
+     * 체스 보드판을 초기화한다.
+     */
+    public void initialize() {
+        clear();
+        initPawn();
     }
 
     /**

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -1,6 +1,7 @@
 package softeer2nd.chess;
 
 import softeer2nd.chess.pieces.Pawn;
+import softeer2nd.chess.pieces.Token;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,14 +10,14 @@ import java.util.List;
  * 체스 보드판을 나타낸다.
  */
 public class Board {
-    private final List<Pawn> tokens = new ArrayList<>();
+    private final List<Token> tokens = new ArrayList<>();
 
     /**
      * 체스 보드판에 새로운 게임 말을 추가한다.
-     * @param pawn 추가할 새로운 게임 말(폰만 허용)
+     * @param token 추가할 새로운 게임 말(폰만 허용)
      */
-    public void add(Pawn pawn) {
-        this.tokens.add(pawn);
+    public void add(Token token) {
+        this.tokens.add(token);
     }
 
     /**
@@ -35,6 +36,11 @@ public class Board {
     public Pawn findPawn(int i) {
         if(this.tokens.size() <= i || i < 0)
             throw new IllegalArgumentException("잘못된 인덱스 접근입니다.");
-        return this.tokens.get(i);
+
+        Token target = this.tokens.get(i);
+        if(target.isPawn())
+            return (Pawn) target;
+
+        throw new IllegalArgumentException("폰 객체가 아닙니다.");
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -18,10 +18,6 @@ public class Board {
     private final List<Token> tokens = new ArrayList<>();
     private final int[][] tokenPosition = new int[COLUMN_NUMBER][ROW_NUMBER];
 
-    public Board() {
-        Arrays.stream(tokenPosition).forEach(column -> Arrays.fill(column, -1));
-    }
-
     /**
      * 체스 보드판에 새로운 게임 말을 추가한다.
      * @param token 추가할 새로운 게임 말
@@ -64,6 +60,11 @@ public class Board {
      * 체스 보드판을 초기화한다.
      */
     public void initialize() {
+        // 할당된 토큰을 모두 삭제한다.
+        tokens.clear();
+        // 토큰의 위치 정보를 제거한다.
+        Arrays.stream(tokenPosition).forEach(column -> Arrays.fill(column, -1));
+
         // 흰색, 검은색 폰을 초기 개수만큼 할당한다.
         for (int i = 0; i < INIT_PAWN_NUMBER; i++) {
             add(new Pawn(Color.BLACK), 1, i);

--- a/src/main/java/softeer2nd/chess/Color.java
+++ b/src/main/java/softeer2nd/chess/Color.java
@@ -1,6 +1,7 @@
 package softeer2nd.chess;
 
-import softeer2nd.chess.pieces.Token;
+import softeer2nd.chess.pieces.Piece;
+import softeer2nd.chess.pieces.PieceType;
 
 public enum Color {
     BLACK("black", 'P'),
@@ -13,8 +14,8 @@ public enum Color {
         this.pawnRepresentation = pawnRepresentation;
     }
 
-    public char getRepresentation(Token token){
-        if(token.isPawn()){
+    public char getRepresentation(Piece piece){
+        if(piece.getPieceType() == PieceType.Pawn){
             return this.pawnRepresentation;
         }
         throw new IllegalArgumentException("정의되지 않은 게임 말입니다.");

--- a/src/main/java/softeer2nd/chess/Color.java
+++ b/src/main/java/softeer2nd/chess/Color.java
@@ -1,0 +1,26 @@
+package softeer2nd.chess;
+
+import softeer2nd.chess.pieces.Token;
+
+public enum Color {
+    BLACK("black", 'P'),
+    WHITE("white", 'p');
+
+    private final String name;
+    private final char pawnRepresentation;
+    Color(String name, char pawnRepresentation) {
+        this.name = name;
+        this.pawnRepresentation = pawnRepresentation;
+    }
+
+    public char getRepresentation(Token token){
+        if(token.isPawn()){
+            return this.pawnRepresentation;
+        }
+        throw new IllegalArgumentException("정의되지 않은 게임 말입니다.");
+    }
+
+    public String getName(){
+        return this.name;
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/pieces/Pawn.java
@@ -1,21 +1,21 @@
 package softeer2nd.chess.pieces;
 
+import softeer2nd.chess.Color;
+
 /**
  * 체스의 폰 객체를 나타낸다.
  */
-public class Pawn {
-    private String color;
-    public static final String WHITE_COLOR = "white";
-    public static final String BLACK_COLOR = "black";
-
+public class Pawn extends Token {
     public Pawn() {
-        this.color = WHITE_COLOR;
-    }
-    public Pawn(String color) {
-        this.color = color;
+        super();
     }
 
-    public String getColor() {
-        return this.color;
+    public Pawn(Color color) {
+        super(color);
+    }
+
+    @Override
+    public boolean isPawn() {
+        return true;
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/pieces/Pawn.java
@@ -5,7 +5,8 @@ import softeer2nd.chess.Color;
 /**
  * 체스의 폰 객체를 나타낸다.
  */
-public class Pawn extends Token {
+public class Pawn extends Piece {
+    private final PieceType pieceType = PieceType.Pawn;
     public Pawn() {
         super();
     }
@@ -15,7 +16,7 @@ public class Pawn extends Token {
     }
 
     @Override
-    public boolean isPawn() {
-        return true;
+    public PieceType getPieceType() {
+        return this.pieceType;
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -2,13 +2,13 @@ package softeer2nd.chess.pieces;
 
 import softeer2nd.chess.Color;
 
-public abstract class Token {
+public abstract class Piece {
     private final Color color;
 
-    public Token() {
+    public Piece() {
         this.color = Color.WHITE;
     }
-    public Token(Color color){
+    public Piece(Color color){
         this.color = color;
     }
 
@@ -20,7 +20,5 @@ public abstract class Token {
         return this.color.getRepresentation(this);
     }
 
-    public boolean isPawn() {
-        return false;
-    }
+    public abstract PieceType getPieceType();
 }

--- a/src/main/java/softeer2nd/chess/pieces/PieceType.java
+++ b/src/main/java/softeer2nd/chess/pieces/PieceType.java
@@ -1,0 +1,5 @@
+package softeer2nd.chess.pieces;
+
+public enum PieceType {
+    Pawn
+}

--- a/src/main/java/softeer2nd/chess/pieces/Token.java
+++ b/src/main/java/softeer2nd/chess/pieces/Token.java
@@ -1,0 +1,26 @@
+package softeer2nd.chess.pieces;
+
+import softeer2nd.chess.Color;
+
+public abstract class Token {
+    private final Color color;
+
+    public Token() {
+        this.color = Color.WHITE;
+    }
+    public Token(Color color){
+        this.color = color;
+    }
+
+    public String getColor(){
+        return this.color.getName();
+    }
+
+    public char getRepresentation() {
+        return this.color.getRepresentation(this);
+    }
+
+    public boolean isPawn() {
+        return false;
+    }
+}

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.pieces.Pawn;
+import softeer2nd.chess.pieces.Token;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class BoardTest {
 
@@ -54,14 +56,23 @@ class BoardTest {
                 {'.','.','.','.','.','.','.','.'},
                 {'.','.','.','.','.','.','.','.'},
                 {'.','.','.','.','.','.','.','.'},
-                {'P','P','P','P','P','P','P','P'},
+                {'p','p','p','p','p','p','p','p'},
                 {'.','.','.','.','.','.','.','.'}};
 
-//        for(int i = 0; i < Board.COLUMN_NUMBER; i++){
-//            for(int j = 0; j < Board.ROW_NUMBER; j++){
-//                assertEquals(initBoard[i][j], board.getTokenByIndex(i, j).getRepresentation());
-//            }
-//        }
+        board.initialize();
+
+        for(int i = 0; i < Board.COLUMN_NUMBER; i++){
+            for(int j = 0; j < Board.ROW_NUMBER; j++){
+                Optional<Token> token = board.getTokenByPosition(i,j);
+                if(initBoard[i][j] == '.') {
+                    assertTrue(token.isEmpty());
+                }
+                else {
+                    assertTrue(token.isPresent());
+                    assertEquals(initBoard[i][j], token.get().getRepresentation());
+                }
+            }
+        }
 
 
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.pieces.Pawn;
-import softeer2nd.chess.pieces.Token;
+import softeer2nd.chess.pieces.Piece;
 
 import java.util.Optional;
 
@@ -67,13 +67,13 @@ class BoardTest {
 
         for(int i = 0; i < Board.COLUMN_NUMBER; i++){
             for(int j = 0; j < Board.ROW_NUMBER; j++){
-                Optional<Token> token = board.getTokenByPosition(i,j);
+                Optional<Piece> piece = board.getPieceByPosition(i,j);
                 if(initBoard[i][j] == '.') {
-                    assertTrue(token.isEmpty());
+                    assertTrue(piece.isEmpty());
                 }
                 else {
-                    assertTrue(token.isPresent());
-                    assertEquals(initBoard[i][j], token.get().getRepresentation());
+                    assertTrue(piece.isPresent());
+                    assertEquals(initBoard[i][j], piece.get().getRepresentation());
                 }
             }
         }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -17,6 +17,7 @@ class BoardTest {
     @BeforeEach
     void setUp() {
         board = new Board();
+        board.clear();
     }
 
     /**
@@ -29,7 +30,7 @@ class BoardTest {
         int beforeSize = board.size();
 
         Pawn pawn = new Pawn(color);
-        board.add(pawn, column,row);
+        board.add(pawn, column, row);
         assertEquals(beforeSize + 1, board.size());
         assertEquals(pawn, board.findPawn(beforeSize));
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class BoardTest {
 
     Board board;
+
     @BeforeEach
     void setUp() {
         board = new Board();
@@ -21,12 +22,14 @@ class BoardTest {
     /**
      * 보드판에 새로운 폰 객체를 추가하는 테스트 단위이다.
      * @param color 추가할 폰 객체 색깔
+     * @param column 추가할 폰 객체 세로축 위치
+     * @param row 추가할 폰 객체 가로축 위치
      */
-    void verifyAddPawnInBoard(final Color color) {
+    void verifyAddPawnInBoard(final Color color, final int column, final int row) {
         int beforeSize = board.size();
 
         Pawn pawn = new Pawn(color);
-        board.add(pawn);
+        board.add(pawn, column,row);
         assertEquals(beforeSize + 1, board.size());
         assertEquals(pawn, board.findPawn(beforeSize));
     }
@@ -34,8 +37,9 @@ class BoardTest {
     @Test
     @DisplayName("보드판 생성 테스트")
     void create(){
-        verifyAddPawnInBoard(Color.WHITE);
-        verifyAddPawnInBoard(Color.BLACK);
+        verifyAddPawnInBoard(Color.WHITE, 0, 0);
+        verifyAddPawnInBoard(Color.BLACK, 0, 1);
+        assertThrows(IllegalArgumentException.class, () -> verifyAddPawnInBoard(Color.BLACK, 0, 1));
     }
 
     @Test
@@ -43,7 +47,7 @@ class BoardTest {
     void find(){
         assertThrows(IllegalArgumentException.class, () -> board.findPawn(-1));
         assertThrows(IllegalArgumentException.class, () -> board.findPawn(0));
-        verifyAddPawnInBoard(Color.WHITE);
+        verifyAddPawnInBoard(Color.WHITE, 0, 0);
     }
 
     @Test

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -1,10 +1,8 @@
 package softeer2nd.chess;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import softeer2nd.chess.pieces.Pawn;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +20,7 @@ class BoardTest {
      * 보드판에 새로운 폰 객체를 추가하는 테스트 단위이다.
      * @param color 추가할 폰 객체 색깔
      */
-    void verifyAddPawnInBoard(final String color) {
+    void verifyAddPawnInBoard(final Color color) {
         int beforeSize = board.size();
 
         Pawn pawn = new Pawn(color);
@@ -34,8 +32,8 @@ class BoardTest {
     @Test
     @DisplayName("보드판 생성 테스트")
     void create(){
-        verifyAddPawnInBoard(Pawn.WHITE_COLOR);
-        verifyAddPawnInBoard(Pawn.BLACK_COLOR);
+        verifyAddPawnInBoard(Color.WHITE);
+        verifyAddPawnInBoard(Color.BLACK);
     }
 
     @Test
@@ -43,6 +41,28 @@ class BoardTest {
     void find(){
         assertThrows(IllegalArgumentException.class, () -> board.findPawn(-1));
         assertThrows(IllegalArgumentException.class, () -> board.findPawn(0));
-        verifyAddPawnInBoard(Pawn.WHITE_COLOR);
+        verifyAddPawnInBoard(Color.WHITE);
+    }
+
+    @Test
+    @DisplayName("체스 보드판 초기화 상태를 검증한다.")
+    void init() {
+        Character[][] initBoard =
+                {{'.','.','.','.','.','.','.','.'},
+                {'P','P','P','P','P','P','P','P'},
+                {'.','.','.','.','.','.','.','.'},
+                {'.','.','.','.','.','.','.','.'},
+                {'.','.','.','.','.','.','.','.'},
+                {'.','.','.','.','.','.','.','.'},
+                {'P','P','P','P','P','P','P','P'},
+                {'.','.','.','.','.','.','.','.'}};
+
+//        for(int i = 0; i < Board.COLUMN_NUMBER; i++){
+//            for(int j = 0; j < Board.ROW_NUMBER; j++){
+//                assertEquals(initBoard[i][j], board.getTokenByIndex(i, j).getRepresentation());
+//            }
+//        }
+
+
     }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -53,7 +53,7 @@ class BoardTest {
     @Test
     @DisplayName("체스 보드판 초기화 상태를 검증한다.")
     void init() {
-        Character[][] initBoard =
+        char[][] initBoard =
                 {{'.','.','.','.','.','.','.','.'},
                 {'P','P','P','P','P','P','P','P'},
                 {'.','.','.','.','.','.','.','.'},
@@ -77,7 +77,22 @@ class BoardTest {
                 }
             }
         }
+    }
 
+    @Test
+    @DisplayName("체스 보드판 문자열 변환이 성공적인지 검증한다.")
+    void print() {
+        String result = "........\n" +
+                "PPPPPPPP\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "pppppppp\n" +
+                "........\n";
 
+        board.initialize();
+
+        assertEquals(result, board.print());
     }
 }

--- a/src/test/java/softeer2nd/chess/pieces/PawnTest.java
+++ b/src/test/java/softeer2nd/chess/pieces/PawnTest.java
@@ -2,9 +2,8 @@ package softeer2nd.chess.pieces;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.pieces.Pawn;
+import softeer2nd.chess.Color;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PawnTest {
@@ -13,22 +12,23 @@ class PawnTest {
      * 특정 색깔 폰이 생성되는지 검증한다.
      * @param color 검증할 폰 색깔을 나타낸다.
      */
-    void verifyPawn(final String color){
+    void verifyPawn(final Color color){
         Pawn pawn = new Pawn(color);
-        assertThat(pawn.getColor()).isEqualTo(color);
+        assertEquals(color.getName(), pawn.getColor());
+        assertEquals(color.getRepresentation(pawn), pawn.getRepresentation());
     }
 
     @Test
     @DisplayName("흰색 및 검은색 폰이 생성되어야 한다")
     void create() {
-        verifyPawn(Pawn.WHITE_COLOR);
-        verifyPawn(Pawn.BLACK_COLOR);
+        verifyPawn(Color.WHITE);
+        verifyPawn(Color.BLACK);
     }
 
     @Test
     void create_기본생성자() throws Exception {
         Pawn pawn = new Pawn();
-        assertEquals(Pawn.WHITE_COLOR, pawn.getColor());
+        assertEquals(Color.WHITE.getName(), pawn.getColor());
     }
 
 


### PR DESCRIPTION
## 구현 내용
- 체스 보드판 초기화 및 상태 출력 구현
- 색깔 관리 객체
- 게임 진행을 위한 main 구현

## 고민 사항
- 체스 말들이 가지는 색깔 정보는 서로 연관성이 있어 하나하나 따로 입력받기 보다 하나의 객체에서 해당 관심사를 분리하여 한번에 처리하는 것이 향후 확장성을 고려했을 때 더 편리할 것 같아서 해당 관심사를 색깔 객체에 분리하여 처리하였다.
- 위 사항을 분리하면서 이후 다른 말들에 대해 확장할 것을 고려하여 공통 메소드를 합친 추상 클래스를 통해 Pawn 객체와 향후 다른 체스 말 객체의 상속을 구현하였다.
- 체스 말을 추가하는 것과 추가된 체스 말의 위치 정보를 처리하기 위해 보드 판의 2차원 배열로 해당 정보를 추가로 저장하였다.

## 기타
