### PR TITLE
[dohyeon-han] step-5 기물 위치 부여 및 점수계산

### DIFF
--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -65,7 +65,7 @@ public class Board {
         System.out.print(showBoard());
     }
 
-    public long pieceCount() {
+    public long countPiece() {
         return this.board.stream()
                 .map(Rank::getRank)
                 .flatMap(List::stream)

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -3,51 +3,62 @@ package softeer2nd.chess;
 import softeer2nd.chess.util.PieceUtils;
 import softeer2nd.chess.util.StringUtils;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class Board {
 
-    private final Piece[][] board = new Piece[8][8];
+    public final int BOARD_LENGTH = 8;
+    private final List<List<Piece>> board = new ArrayList<>(BOARD_LENGTH);
 
     public void initialize() {
+        for (int i = 0; i < BOARD_LENGTH; i++) {
+            List<Piece> row = new ArrayList<>(BOARD_LENGTH);
+            board.add(row);
+        }
         initializeByColor(PieceUtils.Color.WHITE);
         initializeByColor(PieceUtils.Color.BLACK);
+        initializeBlank();
     }
+
 
     private void initializeByColor(PieceUtils.Color color) {
         int pawnRow = color.equals(PieceUtils.Color.BLACK) ? 1 : 6;
         int otherRow = color.equals(PieceUtils.Color.BLACK) ? 0 : 7;
 
         for (int i = 0; i < 8; i++) {
-            board[pawnRow][i] = Piece.createPiece(color, PieceUtils.Type.PAWN);
+            board.get(pawnRow).add(Piece.createPiece(color, PieceUtils.Type.PAWN));
         }
 
-        board[otherRow][0] = Piece.createPiece(color, PieceUtils.Type.ROOK);
-        board[otherRow][7] = Piece.createPiece(color, PieceUtils.Type.ROOK);
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.ROOK));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.QUEEN));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KING));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
+        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.ROOK));
+    }
 
-        board[otherRow][1] = Piece.createPiece(color, PieceUtils.Type.KNIGHT);
-        board[otherRow][6] = Piece.createPiece(color, PieceUtils.Type.KNIGHT);
-
-        board[otherRow][2] = Piece.createPiece(color, PieceUtils.Type.BISHOP);
-        board[otherRow][5] = Piece.createPiece(color, PieceUtils.Type.BISHOP);
-
-        board[otherRow][3] = Piece.createPiece(color, PieceUtils.Type.QUEEN);
-
-        board[otherRow][4] = Piece.createPiece(color, PieceUtils.Type.KING);
+    private void initializeBlank() {
+        for (int i = 2; i < 6; i++) {
+            for (int j = 0; j < BOARD_LENGTH; j++) {
+                board.get(i).add(Piece.createBlank());
+            }
+        }
     }
 
     public String getWhitePawnsResult() {
-        return getRepresentationResult(board[6]);
+        return getRepresentationResult(board.get(6));
     }
 
     public String getBlackPawnsResult() {
-        return getRepresentationResult(board[1]);
+        return getRepresentationResult(board.get(1));
     }
 
-    private String getRepresentationResult(Piece[] row) {
-        return Arrays.stream(row)
-                .map(Piece::getRepresentation)
+    private String getRepresentationResult(List<Piece> row) {
+        return row.stream().map(Piece::getRepresentation)
                 .map(String::valueOf)
                 .collect(Collectors.joining());
     }
@@ -56,25 +67,22 @@ public class Board {
         System.out.print(showBoard());
     }
 
-    public int pieceCount() {
-        int count = 0;
-        for (Piece[] row : board) {
-            for (Piece piece : row) {
-                if (piece == null) continue;
-                count++;
-            }
-        }
-        return count;
+    public long pieceCount() {
+        return this.board.stream()
+                .flatMap(List::stream)
+                .filter(piece -> !piece.getType().equals(PieceUtils.Type.NO_PIECE))
+                .count();
+
     }
 
     public String showBoard() {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 8; i++) {
             for (int j = 0; j < 8; j++) {
-                if (board[i][j] == null) {
+                if (board.get(i).get(j).getType().equals(PieceUtils.Type.NO_PIECE)) {
                     builder.append('.');
                 } else {
-                    builder.append(board[i][j].getRepresentation());
+                    builder.append(board.get(i).get(j).getRepresentation());
                 }
             }
             builder.append(StringUtils.NEWLINE);

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -146,8 +146,11 @@ public class Board {
                 .collect(Collectors.toList());
     }
 
+    // 같은 색의 기물을 기물 별로 map에 점수로 저장한다.
     private Map<PieceUtils.Type, Double> calculatePiecePointsByColumn(PieceUtils.Color color) {
         Map<PieceUtils.Type, Double> points = new HashMap<>();
+
+        // 열 별로 기물 점수 계산
         for (int i = 0; i < BOARD_LENGTH; i++) {
             List<Piece> pieces = getColumnPieces(i, color);
             long countPawn = pieces.stream().filter(piece -> piece.getType().equals(PieceUtils.Type.PAWN)).count();

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -20,21 +20,21 @@ public class Board {
         int otherRow = color.equals(PieceUtils.Color.BLACK) ? 0 : 7;
 
         for (int i = 0; i < 8; i++) {
-            board[pawnRow][i] = new Piece(color, PieceUtils.Type.PAWN);
+            board[pawnRow][i] = Piece.createPiece(color, PieceUtils.Type.PAWN);
         }
 
-        board[otherRow][0] = new Piece(color, PieceUtils.Type.ROOK);
-        board[otherRow][7] = new Piece(color, PieceUtils.Type.ROOK);
+        board[otherRow][0] = Piece.createPiece(color, PieceUtils.Type.ROOK);
+        board[otherRow][7] = Piece.createPiece(color, PieceUtils.Type.ROOK);
 
-        board[otherRow][1] = new Piece(color, PieceUtils.Type.KNIGHT);
-        board[otherRow][6] = new Piece(color, PieceUtils.Type.KNIGHT);
+        board[otherRow][1] = Piece.createPiece(color, PieceUtils.Type.KNIGHT);
+        board[otherRow][6] = Piece.createPiece(color, PieceUtils.Type.KNIGHT);
 
-        board[otherRow][2] = new Piece(color, PieceUtils.Type.BISHOP);
-        board[otherRow][5] = new Piece(color, PieceUtils.Type.BISHOP);
+        board[otherRow][2] = Piece.createPiece(color, PieceUtils.Type.BISHOP);
+        board[otherRow][5] = Piece.createPiece(color, PieceUtils.Type.BISHOP);
 
-        board[otherRow][3] = new Piece(color, PieceUtils.Type.QUEEN);
+        board[otherRow][3] = Piece.createPiece(color, PieceUtils.Type.QUEEN);
 
-        board[otherRow][4] = new Piece(color, PieceUtils.Type.KING);
+        board[otherRow][4] = Piece.createPiece(color, PieceUtils.Type.KING);
     }
 
     public String getWhitePawnsResult() {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -50,6 +50,23 @@ public class Board {
                 .collect(Collectors.joining());
     }
 
+    public Piece findPiece(String pos) {
+        if (pos.length() != 2) {
+            throw new IllegalArgumentException("위치값의 길이는 2입니다.");
+        }
+        char column = pos.charAt(0);
+        char row = pos.charAt(1);
+
+        if (column < 'a' || column > 'h') {
+            throw new IllegalArgumentException("열 값은 a~h입니다.");
+        }
+        if (row < '1' || row > '8') {
+            throw new IllegalArgumentException("열 값은 1~8입니다.");
+        }
+        return this.board.get(7 - (row - '1'))
+                .getPiece(column - 'a');
+    }
+
     public void print() {
         System.out.print(showBoard());
     }
@@ -78,7 +95,7 @@ public class Board {
         return builder.toString();
     }
 
-    public long countPiece(PieceUtils.Color color, PieceUtils.Type type){
+    public long countPiece(PieceUtils.Color color, PieceUtils.Type type) {
         return board.stream()
                 .map(Rank::getRank)
                 .flatMap(List::stream)

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -14,6 +14,7 @@ public class Board {
     private final List<Rank> board = new ArrayList<>(BOARD_LENGTH);
 
     public void initialize() {
+        board.clear();
         for (int i = 0; i < BOARD_LENGTH; i++) {
             board.add(new Rank());
         }
@@ -25,6 +26,7 @@ public class Board {
     }
 
     public void initializeEmpty() {
+        board.clear();
         for (int i = 0; i < BOARD_LENGTH; i++) {
             board.add(new Rank());
         }
@@ -103,6 +105,20 @@ public class Board {
                 .replace(validPositions.get(0), piece);
     }
 
+    public double calculatePoint(PieceUtils.Color color) {
+        double sum = 0.0;
+        for (int i = 0; i < BOARD_LENGTH; i++) {
+            List<Piece> pieces = getColumnPieces(i, color);
+            long countPawn = pieces.stream().filter(piece -> piece.getType().equals(PieceUtils.Type.PAWN)).count();
+
+            // 해당 열에 pawn이 2개 이상 있으면, pawn을 더할 때 반으로 값을 더한다.
+            for (Piece piece : pieces) {
+                sum += piece.getType().getDefaultPoint() / (countPawn > 1 && piece.getType().equals(PieceUtils.Type.PAWN) ? 2.0 : 1.0);
+            }
+        }
+        return sum;
+    }
+
     private List<Integer> getValidPositions(String pos) {
         if (pos.length() != 2) {
             throw new IllegalArgumentException("위치값의 길이는 2입니다.");
@@ -117,5 +133,13 @@ public class Board {
             throw new IllegalArgumentException("열 값은 1~8입니다.");
         }
         return new ArrayList<>(Arrays.asList(column - 'a', 7 - (row - '1')));
+    }
+
+    // 같은 열의 같은 색 기물을 찾는다.
+    private List<Piece> getColumnPieces(int column, PieceUtils.Color color) {
+        return this.board.stream()
+                .map(rank -> rank.getPiece(column))
+                .filter(piece -> piece.getColor().equals(color) && !piece.getType().equals(PieceUtils.Type.NO_PIECE))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -112,9 +112,10 @@ public class Board {
             long countPawn = pieces.stream().filter(piece -> piece.getType().equals(PieceUtils.Type.PAWN)).count();
 
             // 해당 열에 pawn이 2개 이상 있으면, pawn을 더할 때 반으로 값을 더한다.
-            for (Piece piece : pieces) {
-                sum += piece.getType().getDefaultPoint() / (countPawn > 1 && piece.getType().equals(PieceUtils.Type.PAWN) ? 2.0 : 1.0);
-            }
+            sum += pieces.stream()
+                    .mapToDouble(piece -> piece.getType().getDefaultPoint() /
+                            (countPawn > 1 && piece.getType().equals(PieceUtils.Type.PAWN) ? 2.0 : 1.0))
+                    .sum();
         }
         return sum;
     }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -77,4 +77,12 @@ public class Board {
         }
         return builder.toString();
     }
+
+    public long countPiece(PieceUtils.Color color, PieceUtils.Type type){
+        return board.stream()
+                .map(Rank::getRank)
+                .flatMap(List::stream)
+                .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
+                .count();
+    }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -4,6 +4,7 @@ import softeer2nd.chess.util.PieceUtils;
 import softeer2nd.chess.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,9 +19,19 @@ public class Board {
         }
         initializeByColor(PieceUtils.Color.WHITE);
         initializeByColor(PieceUtils.Color.BLACK);
-        initializeBlank();
+        for (int i = 2; i < 6; i++) {
+            board.get(i).initialize(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
+        }
     }
 
+    public void initializeEmpty() {
+        for (int i = 0; i < BOARD_LENGTH; i++) {
+            board.add(new Rank());
+        }
+        for (int i = 0; i < 8; i++) {
+            board.get(i).initialize(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
+        }
+    }
 
     private void initializeByColor(PieceUtils.Color color) {
         int pawnRow = color.equals(PieceUtils.Color.BLACK) ? 1 : 6;
@@ -28,12 +39,6 @@ public class Board {
 
         board.get(pawnRow).initialize(color, PieceUtils.Type.PAWN);
         board.get(otherRow).initializeOthers(color);
-    }
-
-    private void initializeBlank() {
-        for (int i = 2; i < 6; i++) {
-            board.get(i).initialize(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
-        }
     }
 
     public String getWhitePawnsResult() {
@@ -51,20 +56,9 @@ public class Board {
     }
 
     public Piece findPiece(String pos) {
-        if (pos.length() != 2) {
-            throw new IllegalArgumentException("위치값의 길이는 2입니다.");
-        }
-        char column = pos.charAt(0);
-        char row = pos.charAt(1);
-
-        if (column < 'a' || column > 'h') {
-            throw new IllegalArgumentException("열 값은 a~h입니다.");
-        }
-        if (row < '1' || row > '8') {
-            throw new IllegalArgumentException("열 값은 1~8입니다.");
-        }
-        return this.board.get(7 - (row - '1'))
-                .getPiece(column - 'a');
+        List<Integer> validPositions = getValidPositions(pos);
+        return this.board.get(validPositions.get(1))
+                .getPiece(validPositions.get(0));
     }
 
     public void print() {
@@ -101,5 +95,27 @@ public class Board {
                 .flatMap(List::stream)
                 .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
                 .count();
+    }
+
+    public void move(String pos, Piece piece) {
+        List<Integer> validPositions = getValidPositions(pos);
+        this.board.get(validPositions.get(1))
+                .replace(validPositions.get(0), piece);
+    }
+
+    private List<Integer> getValidPositions(String pos) {
+        if (pos.length() != 2) {
+            throw new IllegalArgumentException("위치값의 길이는 2입니다.");
+        }
+        char column = pos.charAt(0);
+        char row = pos.charAt(1);
+
+        if (column < 'a' || column > 'h') {
+            throw new IllegalArgumentException("열 값은 a~h입니다.");
+        }
+        if (row < '1' || row > '8') {
+            throw new IllegalArgumentException("열 값은 1~8입니다.");
+        }
+        return new ArrayList<>(Arrays.asList(column - 'a', 7 - (row - '1')));
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -9,13 +9,12 @@ import java.util.stream.Collectors;
 
 public class Board {
 
-    public final int BOARD_LENGTH = 8;
-    private final List<List<Piece>> board = new ArrayList<>(BOARD_LENGTH);
+    public static final int BOARD_LENGTH = 8;
+    private final List<Rank> board = new ArrayList<>(BOARD_LENGTH);
 
     public void initialize() {
         for (int i = 0; i < BOARD_LENGTH; i++) {
-            List<Piece> row = new ArrayList<>(BOARD_LENGTH);
-            board.add(row);
+            board.add(new Rank());
         }
         initializeByColor(PieceUtils.Color.WHITE);
         initializeByColor(PieceUtils.Color.BLACK);
@@ -27,25 +26,13 @@ public class Board {
         int pawnRow = color.equals(PieceUtils.Color.BLACK) ? 1 : 6;
         int otherRow = color.equals(PieceUtils.Color.BLACK) ? 0 : 7;
 
-        for (int i = 0; i < 8; i++) {
-            board.get(pawnRow).add(Piece.createPiece(color, PieceUtils.Type.PAWN));
-        }
-
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.ROOK));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.QUEEN));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KING));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
-        board.get(otherRow).add(Piece.createPiece(color, PieceUtils.Type.ROOK));
+        board.get(pawnRow).initialize(color, PieceUtils.Type.PAWN);
+        board.get(otherRow).initializeOthers(color);
     }
 
     private void initializeBlank() {
         for (int i = 2; i < 6; i++) {
-            for (int j = 0; j < BOARD_LENGTH; j++) {
-                board.get(i).add(Piece.createBlank());
-            }
+            board.get(i).initialize(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
         }
     }
 
@@ -57,8 +44,8 @@ public class Board {
         return getRepresentationResult(board.get(1));
     }
 
-    private String getRepresentationResult(List<Piece> row) {
-        return row.stream().map(Piece::getRepresentation)
+    private String getRepresentationResult(Rank rank) {
+        return rank.getRank().stream().map(Piece::getRepresentation)
                 .map(String::valueOf)
                 .collect(Collectors.joining());
     }
@@ -69,6 +56,7 @@ public class Board {
 
     public long pieceCount() {
         return this.board.stream()
+                .map(Rank::getRank)
                 .flatMap(List::stream)
                 .filter(piece -> !piece.getType().equals(PieceUtils.Type.NO_PIECE))
                 .count();
@@ -79,10 +67,10 @@ public class Board {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 8; i++) {
             for (int j = 0; j < 8; j++) {
-                if (board.get(i).get(j).getType().equals(PieceUtils.Type.NO_PIECE)) {
+                if (board.get(i).getPiece(j).getType().equals(PieceUtils.Type.NO_PIECE)) {
                     builder.append('.');
                 } else {
-                    builder.append(board.get(i).get(j).getRepresentation());
+                    builder.append(board.get(i).getPiece(j).getRepresentation());
                 }
             }
             builder.append(StringUtils.NEWLINE);

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -74,6 +74,14 @@ public class Board {
 
     }
 
+    public long countPiece(PieceUtils.Color color, PieceUtils.Type type) {
+        return board.stream()
+                .map(Rank::getRank)
+                .flatMap(List::stream)
+                .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
+                .count();
+    }
+
     public String showBoard() {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 8; i++) {
@@ -87,14 +95,6 @@ public class Board {
             builder.append(StringUtils.NEWLINE);
         }
         return builder.toString();
-    }
-
-    public long countPiece(PieceUtils.Color color, PieceUtils.Type type) {
-        return board.stream()
-                .map(Rank::getRank)
-                .flatMap(List::stream)
-                .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
-                .count();
     }
 
     public void move(String pos, Piece piece) {

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -27,7 +27,7 @@ public class Piece {
             } else if (type.equals(PieceUtils.Type.QUEEN)) {
                 return createWhiteQueen();
             }
-        } else {
+        } else if(color.equals(PieceUtils.Color.BLACK)){
             if (type.equals(PieceUtils.Type.PAWN)) {
                 return createBlackPawn();
             } else if (type.equals(PieceUtils.Type.KNIGHT)) {

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -14,87 +14,23 @@ public class Piece {
 
     public static Piece createPiece(PieceUtils.Color color, PieceUtils.Type type) {
         if (color.equals(PieceUtils.Color.WHITE)) {
-            if (type.equals(PieceUtils.Type.PAWN)) {
-                return createWhitePawn();
-            } else if (type.equals(PieceUtils.Type.KNIGHT)) {
-                return createWhiteKnight();
-            } else if (type.equals(PieceUtils.Type.ROOK)) {
-                return createWhiteRook();
-            } else if (type.equals(PieceUtils.Type.BISHOP)) {
-                return createWhiteBishop();
-            } else if (type.equals(PieceUtils.Type.KING)) {
-                return createWhiteKing();
-            } else if (type.equals(PieceUtils.Type.QUEEN)) {
-                return createWhiteQueen();
-            }
+            return createWhite(type);
         } else if(color.equals(PieceUtils.Color.BLACK)){
-            if (type.equals(PieceUtils.Type.PAWN)) {
-                return createBlackPawn();
-            } else if (type.equals(PieceUtils.Type.KNIGHT)) {
-                return createBlackKnight();
-            } else if (type.equals(PieceUtils.Type.ROOK)) {
-                return createBlackRook();
-            } else if (type.equals(PieceUtils.Type.BISHOP)) {
-                return createBlackBishop();
-            } else if (type.equals(PieceUtils.Type.KING)) {
-                return createBlackKing();
-            } else if (type.equals(PieceUtils.Type.QUEEN)) {
-                return createBlackQueen();
-            }
+            return createBlack(type);
         }
         return createBlank();
     }
 
+    public static Piece createWhite(PieceUtils.Type type){
+        return new Piece(PieceUtils.Color.WHITE, type);
+    }
+
+    public static Piece createBlack(PieceUtils.Type type){
+        return new Piece(PieceUtils.Color.BLACK, type);
+    }
+
     public static Piece createBlank() {
         return new Piece(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
-    }
-
-    public static Piece createWhitePawn() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
-    }
-
-    public static Piece createBlackPawn() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.PAWN);
-    }
-
-    public static Piece createWhiteKnight() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
-    }
-
-    public static Piece createBlackKnight() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.KNIGHT);
-    }
-
-    public static Piece createWhiteRook() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
-    }
-
-    public static Piece createBlackRook() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.ROOK);
-    }
-
-    public static Piece createWhiteBishop() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
-    }
-
-    public static Piece createBlackBishop() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.BISHOP);
-    }
-
-    public static Piece createWhiteKing() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
-    }
-
-    public static Piece createBlackKing() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.KING);
-    }
-
-    public static Piece createWhiteQueen() {
-        return new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
-    }
-
-    public static Piece createBlackQueen() {
-        return new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.QUEEN);
     }
 
     public PieceUtils.Color getColor() {

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -108,6 +108,10 @@ public class Piece {
         return Character.toUpperCase(this.type.getBlackRepresentation());
     }
 
+    public PieceUtils.Type getType() {
+        return this.type;
+    }
+
     public boolean isWhite() {
         return this.color.equals(PieceUtils.Color.WHITE);
     }

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -21,11 +21,11 @@ public class Piece {
         return createBlank();
     }
 
-    public static Piece createWhite(PieceUtils.Type type){
+    private static Piece createWhite(PieceUtils.Type type){
         return new Piece(PieceUtils.Color.WHITE, type);
     }
 
-    public static Piece createBlack(PieceUtils.Type type){
+    private static Piece createBlack(PieceUtils.Type type){
         return new Piece(PieceUtils.Color.BLACK, type);
     }
 

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -42,7 +42,11 @@ public class Piece {
                 return createBlackQueen();
             }
         }
-        throw new IllegalArgumentException("적절하지 않은 인자입니다.");
+        return createBlank();
+    }
+
+    public static Piece createBlank() {
+        return new Piece(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
     }
 
     public static Piece createWhitePawn() {

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -7,7 +7,7 @@ public class Piece {
     private final PieceUtils.Color color;
     private final PieceUtils.Type type;
 
-    public Piece(PieceUtils.Color color, PieceUtils.Type type) {
+    private Piece(PieceUtils.Color color, PieceUtils.Type type) {
         this.color = color;
         this.type = type;
     }
@@ -15,17 +15,17 @@ public class Piece {
     public static Piece createPiece(PieceUtils.Color color, PieceUtils.Type type) {
         if (color.equals(PieceUtils.Color.WHITE)) {
             return createWhite(type);
-        } else if(color.equals(PieceUtils.Color.BLACK)){
+        } else if (color.equals(PieceUtils.Color.BLACK)) {
             return createBlack(type);
         }
         return createBlank();
     }
 
-    private static Piece createWhite(PieceUtils.Type type){
+    private static Piece createWhite(PieceUtils.Type type) {
         return new Piece(PieceUtils.Color.WHITE, type);
     }
 
-    private static Piece createBlack(PieceUtils.Type type){
+    private static Piece createBlack(PieceUtils.Type type) {
         return new Piece(PieceUtils.Color.BLACK, type);
     }
 

--- a/src/main/java/softeer2nd/chess/Piece.java
+++ b/src/main/java/softeer2nd/chess/Piece.java
@@ -99,9 +99,9 @@ public class Piece {
 
     public char getRepresentation() {
         if (this.color.equals(PieceUtils.Color.WHITE)) {
-            return this.type.getRepresentation();
+            return this.type.getWhiteRepresentation();
         }
-        return Character.toUpperCase(this.type.getRepresentation());
+        return Character.toUpperCase(this.type.getBlackRepresentation());
     }
 
     public boolean isWhite() {

--- a/src/main/java/softeer2nd/chess/Rank.java
+++ b/src/main/java/softeer2nd/chess/Rank.java
@@ -37,4 +37,8 @@ public class Rank {
     public Piece getPiece(int idx) {
         return this.rank.get(idx);
     }
+
+    public void replace(int idx, Piece piece) {
+        this.rank.set(idx, piece);
+    }
 }

--- a/src/main/java/softeer2nd/chess/Rank.java
+++ b/src/main/java/softeer2nd/chess/Rank.java
@@ -1,0 +1,40 @@
+package softeer2nd.chess;
+
+import softeer2nd.chess.util.PieceUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static softeer2nd.chess.Board.BOARD_LENGTH;
+
+public class Rank {
+
+    private final List<Piece> rank = new ArrayList<>(BOARD_LENGTH);
+
+    public void initialize(PieceUtils.Color color, PieceUtils.Type type) {
+        rank.clear();
+        for (int i = 0; i < BOARD_LENGTH; i++) {
+            this.rank.add(Piece.createPiece(color, type));
+        }
+    }
+
+    public void initializeOthers(PieceUtils.Color color) {
+        rank.clear();
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.ROOK));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.QUEEN));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.KING));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.BISHOP));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.KNIGHT));
+        this.rank.add(Piece.createPiece(color, PieceUtils.Type.ROOK));
+    }
+
+    public List<Piece> getRank() {
+        return new ArrayList<>(this.rank);
+    }
+
+    public Piece getPiece(int idx) {
+        return this.rank.get(idx);
+    }
+}

--- a/src/main/java/softeer2nd/chess/util/PieceUtils.java
+++ b/src/main/java/softeer2nd/chess/util/PieceUtils.java
@@ -7,14 +7,18 @@ public class PieceUtils {
 
     public enum Type {
 
-        PAWN('p'), KNIGHT('n'), ROOK('r'), BISHOP('b'),
-        QUEEN('q'), KING('k'), NO_PIECE('x');
+        PAWN('p', 1.0), ROOK('r', 5.0),
+        KNIGHT('n', 2.5), BISHOP('b', 3.0),
+        QUEEN('q', 9.0), KING('k', 0.0),
+        NO_PIECE('.', 0.0);
 
         private final char representation;
+        private final double defaultPoint;
 
 
-        Type(char representation) {
+        Type(char representation, double defaultPoint) {
             this.representation = representation;
+            this.defaultPoint = defaultPoint;
         }
 
         public char getWhiteRepresentation() {
@@ -23,6 +27,10 @@ public class PieceUtils {
 
         public char getBlackRepresentation() {
             return Character.toUpperCase(this.representation);
+        }
+
+        public double getDefaultPoint() {
+            return this.defaultPoint;
         }
     }
 

--- a/src/main/java/softeer2nd/chess/util/PieceUtils.java
+++ b/src/main/java/softeer2nd/chess/util/PieceUtils.java
@@ -7,7 +7,8 @@ public class PieceUtils {
 
     public enum Type {
 
-        PAWN('p'), KNIGHT('n'), ROOK('r'), BISHOP('b'), QUEEN('q'), KING('k');
+        PAWN('p'), KNIGHT('n'), ROOK('r'), BISHOP('b'),
+        QUEEN('q'), KING('k'), NO_PIECE('x');
 
         private final char representation;
 
@@ -26,6 +27,6 @@ public class PieceUtils {
     }
 
     public enum Color {
-        WHITE, BLACK
+        WHITE, BLACK, NOCOLOR
     }
 }

--- a/src/main/java/softeer2nd/chess/util/PieceUtils.java
+++ b/src/main/java/softeer2nd/chess/util/PieceUtils.java
@@ -16,8 +16,12 @@ public class PieceUtils {
             this.representation = representation;
         }
 
-        public char getRepresentation() {
-            return representation;
+        public char getWhiteRepresentation() {
+            return this.representation;
+        }
+
+        public char getBlackRepresentation() {
+            return Character.toUpperCase(this.representation);
         }
     }
 

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -52,7 +52,7 @@ public class BoardTest {
     @Test
     @DisplayName("체스판의 전체 상태를 확인한다.")
     public void create() {
-        assertThat(32).isEqualTo(board.pieceCount());
+        assertThat(32).isEqualTo(board.countPiece());
         assertThat(getInitStatusString())
                 .isEqualTo(board.showBoard());
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -118,6 +118,23 @@ public class BoardTest {
         assertThrows(IllegalArgumentException.class, () -> board.findPiece(pos));
     }
 
+    @Test
+    @DisplayName("빈 체스판에 검정룩을 b5에 놓는다.")
+    public void move() {
+        //given
+        board.initializeEmpty();
+
+        String position = "b5";
+        Piece piece = Piece.createPiece(Color.BLACK, Type.ROOK);
+
+        //when
+        board.move(position, piece);
+
+        //then
+        assertThat(piece).isEqualToComparingFieldByFieldRecursively(board.findPiece(position));
+        System.out.println(board.showBoard());
+    }
+
     private String getInitStatusString() {
         String blankRank = appendNewLine("........");
         return appendNewLine("RNBQKBNR") +

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static softeer2nd.chess.util.StringUtils.appendNewLine;
 
@@ -35,13 +36,17 @@ public class BoardTest {
     @Test
     @DisplayName("초기화한 체스판을 출력한다.")
     public void printInitialize() {
+        // 이전의 System.out 저장
+        PrintStream originalOut = System.out;
+
         ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStreamCaptor));
 
         board.print();
         assertThat(outputStreamCaptor.toString()).isEqualTo(getInitStatusString());
 
-        System.setOut(new PrintStream(System.out));
+        // System.out을 이전의 PrintStream으로 복원
+        System.setOut(originalOut);
     }
 
     @Test
@@ -133,6 +138,34 @@ public class BoardTest {
         //then
         assertThat(piece).isEqualToComparingFieldByFieldRecursively(board.findPiece(position));
         System.out.println(board.showBoard());
+    }
+
+    @Test
+    @DisplayName("색깔 별로 기물 점수의 합을 구한다.")
+    public void calculatePoint() throws Exception {
+        board.initializeEmpty();
+
+        addPiece("b6", Piece.createPiece(Color.BLACK, Type.PAWN));
+        addPiece("e6", Piece.createPiece(Color.BLACK, Type.QUEEN));
+        addPiece("b8", Piece.createPiece(Color.BLACK, Type.KING));
+        addPiece("c8", Piece.createPiece(Color.BLACK, Type.ROOK));
+
+        addPiece("g4", Piece.createPiece(Color.WHITE, Type.PAWN));
+        addPiece("g3", Piece.createPiece(Color.WHITE, Type.PAWN));
+        addPiece("g2", Piece.createPiece(Color.WHITE, Type.PAWN));
+        addPiece("f3", Piece.createPiece(Color.WHITE, Type.PAWN));
+        addPiece("f2", Piece.createPiece(Color.WHITE, Type.PAWN));
+        addPiece("e1", Piece.createPiece(Color.WHITE, Type.ROOK));
+        addPiece("f1", Piece.createPiece(Color.WHITE, Type.KING));
+
+        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.5, board.calculatePoint(Color.WHITE), 0.01);
+
+        System.out.println(board.showBoard());
+    }
+
+    private void addPiece(String position, Piece piece) {
+        board.move(position, piece);
     }
 
     private String getInitStatusString() {

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -3,6 +3,7 @@ package softeer2nd.chess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import softeer2nd.chess.util.PieceUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -45,6 +46,47 @@ public class BoardTest {
         assertThat(getInitStatusString())
                 .isEqualTo(board.showBoard());
     }
+
+    @Test
+    @DisplayName("초기화한 체스판에서 흰 기물의 각 개수를 확인한다.")
+    public void countWhitePiece() {
+        //when
+        long pawn = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
+        long rook = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
+        long knight = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
+        long bishop = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
+        long king = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
+        long queen = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
+
+        //then
+        assertThat(pawn).isEqualTo(8);
+        assertThat(rook).isEqualTo(2);
+        assertThat(knight).isEqualTo(2);
+        assertThat(bishop).isEqualTo(2);
+        assertThat(king).isEqualTo(1);
+        assertThat(queen).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("초기화한 체스판에서 검정 기물의 각 개수를 확인한다.")
+    public void countBlackPiece() {
+        //when
+        long pawn = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
+        long rook = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
+        long knight = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
+        long bishop = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
+        long king = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
+        long queen = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
+
+        //then
+        assertThat(pawn).isEqualTo(8);
+        assertThat(rook).isEqualTo(2);
+        assertThat(knight).isEqualTo(2);
+        assertThat(bishop).isEqualTo(2);
+        assertThat(king).isEqualTo(1);
+        assertThat(queen).isEqualTo(1);
+    }
+
 
     private String getInitStatusString() {
         String blankRank = appendNewLine("........");

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -160,8 +160,8 @@ public class BoardTest {
         addPieces();
 
         //when
-        List<Double> whitePoints = board.getPointsAsc(Color.WHITE);
-        List<Double> blackPoints = board.getPointsAsc(Color.BLACK);
+        List<Double> whitePoints = board.getPiecePointsAsc(Color.WHITE);
+        List<Double> blackPoints = board.getPiecePointsAsc(Color.BLACK);
 
         //then
         List<Double> expectedWhitePoints = Arrays.asList(0.0, 2.5, 5.0);
@@ -177,8 +177,8 @@ public class BoardTest {
         addPieces();
 
         //when
-        List<Double> whitePoints = board.getPointsDesc(Color.WHITE);
-        List<Double> blackPoints = board.getPointsDesc(Color.BLACK);
+        List<Double> whitePoints = board.getPiecePointsDesc(Color.WHITE);
+        List<Double> blackPoints = board.getPiecePointsDesc(Color.BLACK);
 
         //then
         List<Double> expectedWhitePoints = Arrays.asList(5.0, 2.5, 0.0);

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -7,6 +7,9 @@ import softeer2nd.chess.util.PieceUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static softeer2nd.chess.util.StringUtils.appendNewLine;
@@ -51,40 +54,20 @@ public class BoardTest {
     @DisplayName("초기화한 체스판에서 흰 기물의 각 개수를 확인한다.")
     public void countWhitePiece() {
         //when
-        long pawn = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
-        long rook = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
-        long knight = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
-        long bishop = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
-        long king = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
-        long queen = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
+        List<Long> counts = getCountList(PieceUtils.Color.WHITE);
 
         //then
-        assertThat(pawn).isEqualTo(8);
-        assertThat(rook).isEqualTo(2);
-        assertThat(knight).isEqualTo(2);
-        assertThat(bishop).isEqualTo(2);
-        assertThat(king).isEqualTo(1);
-        assertThat(queen).isEqualTo(1);
+        verifyPiecesCount(counts);
     }
 
     @Test
     @DisplayName("초기화한 체스판에서 검정 기물의 각 개수를 확인한다.")
     public void countBlackPiece() {
         //when
-        long pawn = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
-        long rook = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
-        long knight = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
-        long bishop = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
-        long king = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
-        long queen = board.countPiece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
+        List<Long> counts = getCountList(PieceUtils.Color.BLACK);
 
         //then
-        assertThat(pawn).isEqualTo(8);
-        assertThat(rook).isEqualTo(2);
-        assertThat(knight).isEqualTo(2);
-        assertThat(bishop).isEqualTo(2);
-        assertThat(king).isEqualTo(1);
-        assertThat(queen).isEqualTo(1);
+        verifyPiecesCount(counts);
     }
 
 
@@ -95,5 +78,26 @@ public class BoardTest {
                 blankRank + blankRank + blankRank + blankRank +
                 appendNewLine("pppppppp") +
                 appendNewLine("rnbqkbnr");
+    }
+
+    private List<Long> getCountList(PieceUtils.Color color) {
+        List<Long> counts = new ArrayList<>();
+        counts.add(board.countPiece(color, PieceUtils.Type.PAWN));
+        counts.add(board.countPiece(color, PieceUtils.Type.ROOK));
+        counts.add(board.countPiece(color, PieceUtils.Type.KNIGHT));
+        counts.add(board.countPiece(color, PieceUtils.Type.BISHOP));
+        counts.add(board.countPiece(color, PieceUtils.Type.KING));
+        counts.add(board.countPiece(color, PieceUtils.Type.QUEEN));
+
+        return counts;
+    }
+
+    private void verifyPiecesCount(List<Long> counts) {
+        final int LENGTH = 6;
+        List<Long> expectedCounts = new ArrayList<>(Arrays.asList(8L, 2L, 2L, 2L, 1L, 1L));
+        assertThat(counts).hasSize(LENGTH);
+        for (int i = 0; i < LENGTH; i++) {
+            assertThat(counts.get(i)).isEqualTo(expectedCounts.get(i));
+        }
     }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -143,6 +143,64 @@ public class BoardTest {
     @Test
     @DisplayName("색깔 별로 기물 점수의 합을 구한다.")
     public void calculatePoint() throws Exception {
+        //given
+        addPieces();
+
+        //then
+        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.5, board.calculatePoint(Color.WHITE), 0.01);
+
+        System.out.println(board.showBoard());
+    }
+
+    @Test
+    @DisplayName("기물 점수의 합을 오름차순 정렬한다.")
+    public void sumPiecesAsc() {
+        //given
+        addPieces();
+
+        //when
+        List<Double> whitePoints = board.getPointsAsc(Color.WHITE);
+        List<Double> blackPoints = board.getPointsAsc(Color.BLACK);
+
+        //then
+        List<Double> expectedWhitePoints = Arrays.asList(0.0, 2.5, 5.0);
+        List<Double> expectedBlackPoints = Arrays.asList(0.0, 1.0, 5.0, 9.0);
+        assertThat(whitePoints).usingRecursiveFieldByFieldElementComparator().isEqualTo(expectedWhitePoints);
+        assertThat(blackPoints).usingRecursiveFieldByFieldElementComparator().isEqualTo(expectedBlackPoints);
+    }
+
+    @Test
+    @DisplayName("기물 점수의 합을 내림차순 정렬한다.")
+    public void sumPiecesDesc() {
+        //given
+        addPieces();
+
+        //when
+        List<Double> whitePoints = board.getPointsDesc(Color.WHITE);
+        List<Double> blackPoints = board.getPointsDesc(Color.BLACK);
+
+        //then
+        List<Double> expectedWhitePoints = Arrays.asList(5.0, 2.5, 0.0);
+        List<Double> expectedBlackPoints = Arrays.asList(9.0, 5.0, 1.0, 0.0);
+        assertThat(whitePoints).usingRecursiveFieldByFieldElementComparator().isEqualTo(expectedWhitePoints);
+        assertThat(blackPoints).usingRecursiveFieldByFieldElementComparator().isEqualTo(expectedBlackPoints);
+    }
+
+    private void addPiece(String position, Piece piece) {
+        board.move(position, piece);
+    }
+
+    private String getInitStatusString() {
+        String blankRank = appendNewLine("........");
+        return appendNewLine("RNBQKBNR") +
+                appendNewLine("PPPPPPPP") +
+                blankRank + blankRank + blankRank + blankRank +
+                appendNewLine("pppppppp") +
+                appendNewLine("rnbqkbnr");
+    }
+
+    private void addPieces() {
         board.initializeEmpty();
 
         addPiece("b6", Piece.createPiece(Color.BLACK, Type.PAWN));
@@ -158,23 +216,6 @@ public class BoardTest {
         addPiece("e1", Piece.createPiece(Color.WHITE, Type.ROOK));
         addPiece("f1", Piece.createPiece(Color.WHITE, Type.KING));
 
-        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
-        assertEquals(7.5, board.calculatePoint(Color.WHITE), 0.01);
-
-        System.out.println(board.showBoard());
-    }
-
-    private void addPiece(String position, Piece piece) {
-        board.move(position, piece);
-    }
-
-    private String getInitStatusString() {
-        String blankRank = appendNewLine("........");
-        return appendNewLine("RNBQKBNR") +
-                appendNewLine("PPPPPPPP") +
-                blankRank + blankRank + blankRank + blankRank +
-                appendNewLine("pppppppp") +
-                appendNewLine("rnbqkbnr");
     }
 
     private List<Long> getCountList(Color color) {

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -3,7 +3,7 @@ package softeer2nd.chess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.util.PieceUtils;
+import softeer2nd.chess.util.PieceUtils.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -54,7 +54,7 @@ public class BoardTest {
     @DisplayName("초기화한 체스판에서 흰 기물의 각 개수를 확인한다.")
     public void countWhitePiece() {
         //when
-        List<Long> counts = getCountList(PieceUtils.Color.WHITE);
+        List<Long> counts = getCountList(Color.WHITE);
 
         //then
         verifyPiecesCount(counts);
@@ -64,12 +64,11 @@ public class BoardTest {
     @DisplayName("초기화한 체스판에서 검정 기물의 각 개수를 확인한다.")
     public void countBlackPiece() {
         //when
-        List<Long> counts = getCountList(PieceUtils.Color.BLACK);
+        List<Long> counts = getCountList(Color.BLACK);
 
         //then
         verifyPiecesCount(counts);
     }
-
 
     private String getInitStatusString() {
         String blankRank = appendNewLine("........");
@@ -80,14 +79,14 @@ public class BoardTest {
                 appendNewLine("rnbqkbnr");
     }
 
-    private List<Long> getCountList(PieceUtils.Color color) {
+    private List<Long> getCountList(Color color) {
         List<Long> counts = new ArrayList<>();
-        counts.add(board.countPiece(color, PieceUtils.Type.PAWN));
-        counts.add(board.countPiece(color, PieceUtils.Type.ROOK));
-        counts.add(board.countPiece(color, PieceUtils.Type.KNIGHT));
-        counts.add(board.countPiece(color, PieceUtils.Type.BISHOP));
-        counts.add(board.countPiece(color, PieceUtils.Type.KING));
-        counts.add(board.countPiece(color, PieceUtils.Type.QUEEN));
+        counts.add(board.countPiece(color, Type.PAWN));
+        counts.add(board.countPiece(color, Type.ROOK));
+        counts.add(board.countPiece(color, Type.KNIGHT));
+        counts.add(board.countPiece(color, Type.BISHOP));
+        counts.add(board.countPiece(color, Type.KING));
+        counts.add(board.countPiece(color, Type.QUEEN));
 
         return counts;
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -3,7 +3,8 @@ package softeer2nd.chess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.util.PieceUtils.*;
+import softeer2nd.chess.util.PieceUtils.Color;
+import softeer2nd.chess.util.PieceUtils.Type;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -12,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static softeer2nd.chess.util.StringUtils.appendNewLine;
 
 public class BoardTest {
@@ -68,6 +70,52 @@ public class BoardTest {
 
         //then
         verifyPiecesCount(counts);
+    }
+
+    @Test
+    @DisplayName("모든 룩의 위치를 확인한다.")
+    public void findRook() {
+        board.initialize();
+
+        assertThat(Piece.createPiece(Color.BLACK, Type.ROOK)).isEqualToComparingFieldByFieldRecursively(board.findPiece("a8"));
+        assertThat(Piece.createPiece(Color.BLACK, Type.ROOK)).isEqualToComparingFieldByFieldRecursively(board.findPiece("h8"));
+        assertThat(Piece.createPiece(Color.WHITE, Type.ROOK)).isEqualToComparingFieldByFieldRecursively(board.findPiece("a1"));
+        assertThat(Piece.createPiece(Color.WHITE, Type.ROOK)).isEqualToComparingFieldByFieldRecursively(board.findPiece("h1"));
+    }
+
+    @Test
+    @DisplayName("기물을 찾는 인자의 길이가 3이 아니면 예외가 발생한다.")
+    public void findPieceLengthException() {
+        //given
+        String shortPos = "a";
+        String longPos = "b23";
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () -> board.findPiece(shortPos));
+        assertThrows(IllegalArgumentException.class, () -> board.findPiece(longPos));
+    }
+
+    @Test
+    @DisplayName("기물을 찾는 행 1~8이 아니면 예외가 발생한다.")
+    public void findPieceRowException() {
+        //given
+        String pos = "a9";
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () -> board.findPiece(pos));
+    }
+
+    @Test
+    @DisplayName("기물을 찾는 행 a~h가 아니면 예외가 발생한다.")
+    public void findPieceColumnException() {
+        //given
+        String pos = "i2";
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () -> board.findPiece(pos));
     }
 
     private String getInitStatusString() {

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -3,6 +3,7 @@ package softeer2nd.chess;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.util.PieceUtils;
+import softeer2nd.chess.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,5 +57,29 @@ class PieceTest {
         else {
             assertThat(piece.getRepresentation()).isEqualTo(Character.toUpperCase(type.getBlackRepresentation()));
         }
+    }
+
+    @Test
+    @DisplayName("색이 다른 같은 종류의 Piece 비교")
+    public void create_piece() {
+        verifyPiece(Piece.createWhitePawn(), Piece.createBlackPawn(), PieceUtils.Type.PAWN);
+        verifyPiece(Piece.createWhiteKnight(), Piece.createBlackKnight(), PieceUtils.Type.KNIGHT);
+        verifyPiece(Piece.createWhiteRook(), Piece.createBlackRook(), PieceUtils.Type.ROOK);
+        verifyPiece(Piece.createWhiteBishop(), Piece.createBlackBishop(), PieceUtils.Type.BISHOP);
+        verifyPiece(Piece.createWhiteQueen(), Piece.createBlackQueen(), PieceUtils.Type.QUEEN);
+        verifyPiece(Piece.createWhiteKing(), Piece.createBlackKing(), PieceUtils.Type.KING);
+
+        Piece blank = Piece.createBlank();
+        assertThat(blank.isWhite()).isFalse();
+        assertThat(blank.isBlack()).isFalse();
+        assertThat(blank.getType()).isEqualTo(PieceUtils.Type.NO_PIECE);
+    }
+
+    private void verifyPiece(final Piece whitePiece, final Piece blackPiece, final PieceUtils.Type type) {
+        assertThat(whitePiece.isWhite()).isTrue();
+        assertThat(whitePiece.getType()).isEqualTo(type);
+
+        assertThat(blackPiece.isBlack()).isTrue();
+        assertThat(blackPiece.getType()).isEqualTo(type);
     }
 }

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -61,12 +61,12 @@ class PieceTest {
     @Test
     @DisplayName("색이 다른 같은 종류의 Piece 비교")
     public void create_piece() {
-        verifyPiece(Piece.createWhitePawn(), Piece.createBlackPawn(), PieceUtils.Type.PAWN);
-        verifyPiece(Piece.createWhiteKnight(), Piece.createBlackKnight(), PieceUtils.Type.KNIGHT);
-        verifyPiece(Piece.createWhiteRook(), Piece.createBlackRook(), PieceUtils.Type.ROOK);
-        verifyPiece(Piece.createWhiteBishop(), Piece.createBlackBishop(), PieceUtils.Type.BISHOP);
-        verifyPiece(Piece.createWhiteQueen(), Piece.createBlackQueen(), PieceUtils.Type.QUEEN);
-        verifyPiece(Piece.createWhiteKing(), Piece.createBlackKing(), PieceUtils.Type.KING);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.PAWN), Piece.createBlack(PieceUtils.Type.PAWN), PieceUtils.Type.PAWN);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.KNIGHT), Piece.createBlack(PieceUtils.Type.KNIGHT), PieceUtils.Type.KNIGHT);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.ROOK), Piece.createBlack(PieceUtils.Type.ROOK), PieceUtils.Type.ROOK);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.BISHOP), Piece.createBlack(PieceUtils.Type.BISHOP), PieceUtils.Type.BISHOP);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.QUEEN), Piece.createBlack(PieceUtils.Type.QUEEN), PieceUtils.Type.QUEEN);
+        verifyPiece(Piece.createWhite(PieceUtils.Type.KING), Piece.createBlack(PieceUtils.Type.KING), PieceUtils.Type.KING);
 
         Piece blank = Piece.createBlank();
         assertThat(blank.isWhite()).isFalse();

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -51,10 +51,10 @@ class PieceTest {
     private void verifyPiece(Piece piece, final PieceUtils.Color color, final PieceUtils.Type type){
         assertThat(piece.getColor()).isEqualTo(color);
         if(color.equals(PieceUtils.Color.WHITE)) {
-            assertThat(piece.getRepresentation()).isEqualTo(type.getRepresentation());
+            assertThat(piece.getRepresentation()).isEqualTo(type.getWhiteRepresentation());
         }
         else {
-            assertThat(piece.getRepresentation()).isEqualTo(Character.toUpperCase(type.getRepresentation()));
+            assertThat(piece.getRepresentation()).isEqualTo(Character.toUpperCase(type.getBlackRepresentation()));
         }
     }
 }

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -33,7 +33,7 @@ class PieceTest {
     @Test
     @DisplayName("Piece의 색이 검정색인지 확인한다.")
     public void isBlack() {
-        Piece black = new Piece(Color.BLACK, Type.KING);
+        Piece black = Piece.createPiece(Color.BLACK, Type.KING);
 
         assertThat(black.isBlack()).isTrue();
         assertThat(black.isWhite()).isFalse();
@@ -42,7 +42,7 @@ class PieceTest {
     @Test
     @DisplayName("Piece의 색이 하얀색인지 확인한다.")
     public void isWhite() {
-        Piece white = new Piece(Color.WHITE, Type.KING);
+        Piece white = Piece.createPiece(Color.WHITE, Type.KING);
 
         assertThat(white.isBlack()).isFalse();
         assertThat(white.isWhite()).isTrue();

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -2,7 +2,7 @@ package softeer2nd.chess;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.util.PieceUtils;
+import softeer2nd.chess.util.PieceUtils.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,29 +11,29 @@ class PieceTest {
     @Test
     @DisplayName("기물을 생성한다")
     public void createPiece() {
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN), PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.PAWN), PieceUtils.Color.BLACK, PieceUtils.Type.PAWN);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.PAWN), Color.WHITE, Type.PAWN);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.PAWN), Color.BLACK, Type.PAWN);
 
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT), PieceUtils.Color.WHITE, PieceUtils.Type.KNIGHT);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.KNIGHT), PieceUtils.Color.BLACK, PieceUtils.Type.KNIGHT);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.KNIGHT), Color.WHITE, Type.KNIGHT);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.KNIGHT), Color.BLACK, Type.KNIGHT);
 
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.ROOK), PieceUtils.Color.WHITE, PieceUtils.Type.ROOK);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.ROOK), PieceUtils.Color.BLACK, PieceUtils.Type.ROOK);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.ROOK), Color.WHITE, Type.ROOK);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.ROOK), Color.BLACK, Type.ROOK);
 
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.KING), PieceUtils.Color.WHITE, PieceUtils.Type.KING);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.KING), PieceUtils.Color.BLACK, PieceUtils.Type.KING);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.KING), Color.WHITE, Type.KING);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.KING), Color.BLACK, Type.KING);
 
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP), PieceUtils.Color.WHITE, PieceUtils.Type.BISHOP);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.BISHOP), PieceUtils.Color.BLACK, PieceUtils.Type.BISHOP);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.BISHOP), Color.WHITE, Type.BISHOP);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.BISHOP), Color.BLACK, Type.BISHOP);
 
-        verifyPiece(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN), PieceUtils.Color.WHITE, PieceUtils.Type.QUEEN);
-        verifyPiece(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.QUEEN), PieceUtils.Color.BLACK, PieceUtils.Type.QUEEN);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.QUEEN), Color.WHITE, Type.QUEEN);
+        verifyPiece(Piece.createPiece(Color.BLACK, Type.QUEEN), Color.BLACK, Type.QUEEN);
     }
 
     @Test
     @DisplayName("Piece의 색이 검정색인지 확인한다.")
     public void isBlack() {
-        Piece black = new Piece(PieceUtils.Color.BLACK, PieceUtils.Type.KING);
+        Piece black = new Piece(Color.BLACK, Type.KING);
 
         assertThat(black.isBlack()).isTrue();
         assertThat(black.isWhite()).isFalse();
@@ -42,15 +42,15 @@ class PieceTest {
     @Test
     @DisplayName("Piece의 색이 하얀색인지 확인한다.")
     public void isWhite() {
-        Piece white = new Piece(PieceUtils.Color.WHITE, PieceUtils.Type.KING);
+        Piece white = new Piece(Color.WHITE, Type.KING);
 
         assertThat(white.isBlack()).isFalse();
         assertThat(white.isWhite()).isTrue();
     }
 
-    private void verifyPiece(Piece piece, final PieceUtils.Color color, final PieceUtils.Type type){
+    private void verifyPiece(Piece piece, final Color color, final Type type){
         assertThat(piece.getColor()).isEqualTo(color);
-        if(color.equals(PieceUtils.Color.WHITE)) {
+        if(color.equals(Color.WHITE)) {
             assertThat(piece.getRepresentation()).isEqualTo(type.getWhiteRepresentation());
         }
         else {
@@ -61,20 +61,20 @@ class PieceTest {
     @Test
     @DisplayName("색이 다른 같은 종류의 Piece 비교")
     public void create_piece() {
-        verifyPiece(Piece.createWhite(PieceUtils.Type.PAWN), Piece.createBlack(PieceUtils.Type.PAWN), PieceUtils.Type.PAWN);
-        verifyPiece(Piece.createWhite(PieceUtils.Type.KNIGHT), Piece.createBlack(PieceUtils.Type.KNIGHT), PieceUtils.Type.KNIGHT);
-        verifyPiece(Piece.createWhite(PieceUtils.Type.ROOK), Piece.createBlack(PieceUtils.Type.ROOK), PieceUtils.Type.ROOK);
-        verifyPiece(Piece.createWhite(PieceUtils.Type.BISHOP), Piece.createBlack(PieceUtils.Type.BISHOP), PieceUtils.Type.BISHOP);
-        verifyPiece(Piece.createWhite(PieceUtils.Type.QUEEN), Piece.createBlack(PieceUtils.Type.QUEEN), PieceUtils.Type.QUEEN);
-        verifyPiece(Piece.createWhite(PieceUtils.Type.KING), Piece.createBlack(PieceUtils.Type.KING), PieceUtils.Type.KING);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.PAWN), Piece.createPiece(Color.BLACK, Type.PAWN), Type.PAWN);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.KNIGHT), Piece.createPiece(Color.BLACK, Type.KNIGHT), Type.KNIGHT);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.ROOK), Piece.createPiece(Color.BLACK, Type.ROOK), Type.ROOK);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.BISHOP), Piece.createPiece(Color.BLACK, Type.BISHOP), Type.BISHOP);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.QUEEN), Piece.createPiece(Color.BLACK, Type.QUEEN), Type.QUEEN);
+        verifyPiece(Piece.createPiece(Color.WHITE, Type.KING), Piece.createPiece(Color.BLACK, Type.KING), Type.KING);
 
         Piece blank = Piece.createBlank();
         assertThat(blank.isWhite()).isFalse();
         assertThat(blank.isBlack()).isFalse();
-        assertThat(blank.getType()).isEqualTo(PieceUtils.Type.NO_PIECE);
+        assertThat(blank.getType()).isEqualTo(Type.NO_PIECE);
     }
 
-    private void verifyPiece(final Piece whitePiece, final Piece blackPiece, final PieceUtils.Type type) {
+    private void verifyPiece(final Piece whitePiece, final Piece blackPiece, final Type type) {
         assertThat(whitePiece.isWhite()).isTrue();
         assertThat(whitePiece.getType()).isEqualTo(type);
 

--- a/src/test/java/softeer2nd/chess/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/PieceTest.java
@@ -3,7 +3,6 @@ package softeer2nd.chess;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.util.PieceUtils;
-import softeer2nd.chess.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/softeer2nd/chess/RankTest.java
+++ b/src/test/java/softeer2nd/chess/RankTest.java
@@ -1,0 +1,79 @@
+package softeer2nd.chess;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import softeer2nd.chess.util.PieceUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RankTest {
+
+    @Test
+    @DisplayName("blank로 초기화한다.")
+    public void initializeWithBlank() {
+        //given
+        Rank rank = new Rank();
+
+        //when
+        rank.initialize(PieceUtils.Color.NOCOLOR, PieceUtils.Type.NO_PIECE);
+
+        //then
+        List<Piece> list = rank.getRank();
+        assertThat(list).hasSize(8);
+        for (Piece blank : rank.getRank()) {
+            assertThat(blank).isEqualToComparingFieldByFieldRecursively(Piece.createBlank());
+        }
+    }
+
+    @Test
+    @DisplayName("Rank가 흰색 폰으로 초기화된다.")
+    public void initializeWithPawn() {
+        //given
+        Rank rank = new Rank();
+
+        //when
+        rank.initialize(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN);
+
+        //then
+        List<Piece> list = rank.getRank();
+        assertThat(list).hasSize(8);
+
+        for (Piece pawn : list) {
+            assertThat(pawn)
+                    .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.WHITE, PieceUtils.Type.PAWN));
+        }
+    }
+
+    @Test
+    @DisplayName("Rank가 pawn제외한 다른 기물들로 초기화된다.")
+    public void initializeWithOthers() {
+        //given
+        Rank rank = new Rank();
+
+        //when
+        rank.initializeOthers(PieceUtils.Color.BLACK);
+
+        //then
+        List<Piece> list = rank.getRank();
+        assertThat(list).hasSize(8);
+
+        assertThat(list.get(0))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.ROOK));
+        assertThat(list.get(1))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.KNIGHT));
+        assertThat(list.get(2))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.BISHOP));
+        assertThat(list.get(3))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.QUEEN));
+        assertThat(list.get(4))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.KING));
+        assertThat(list.get(5))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.BISHOP));
+        assertThat(list.get(6))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.KNIGHT));
+        assertThat(list.get(7))
+                .isEqualToComparingFieldByFieldRecursively(Piece.createPiece(PieceUtils.Color.BLACK, PieceUtils.Type.ROOK));
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 빈 기물 및 빈 체스판 생성
- Type enum에 기물의 점수 추가
- 2차원 배열에서 List<Rank>로 체스판 구조 변경
- 기물 점수의 합, 색깔 별 기물의 정렬 값 반환 메소드 구현
- calculatePiecePointsByColumn로 기물 점수 계산 관련 중복 로직 처리

## 고민 사항
- 각 기물 이름을 클래스로 만들고 Piece라는 인터페이스를 만들어 상속받게 한다면 인터페이스를 활용할 수 있을 듯 한데, 그렇게 구현하지 않았기 때문에, 지금 상황에서는 인터페이스를 사용해서 크게 이득을 볼 수 있는 상황이 떠오르질 않는다.

## 기타
