### PR TITLE
[kimahhh] step-5 기물 위치 부여 및 점수계산

### DIFF
--- a/src/main/java/softeer2nd/Player.java
+++ b/src/main/java/softeer2nd/Player.java
@@ -30,7 +30,7 @@ public class Player {
     private static void startGame() {
         System.out.println("Game is start");
         Board board = new Board();
-        board.initialize();
+        board.initializeBasic();
         System.out.println(board.showBoard());
     }
 

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -23,11 +23,17 @@ public class Board {
     }
 
     public int pieceCount() {
-        return pieces.size();
+        return (int) board.stream()
+                .flatMap(rank -> rank.rank.stream())
+                .filter(piece -> !piece.getType().equals(Type.NO_PIECE))
+                .count();
     }
 
-    public Piece findPawn(int index) {
-        return pieces.get(index);
+    public int pieceCount(Color color, Type type) {
+        return (int) board.stream()
+                .flatMap(rank -> rank.rank.stream())
+                .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
+                .count();
     }
 
     public String getRankResult(int index) {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -10,7 +10,7 @@ import static softeer2nd.utils.StringUtils.appendNewLine;
 public class Board {
     private static final int BOARD_SIZE = 8;
     private static final int EMPTY_ROW_NUM = 4;
-    private ArrayList<ArrayList<Object>> board;
+    private ArrayList<Rank> board;
     private ArrayList<Piece> pieces;
 
     public Board() {
@@ -30,23 +30,21 @@ public class Board {
         return pieces.get(index);
     }
 
-    public String getRowResult(int index) {
+    public String getRankResult(int index) {
+        index = 8 - index;
         StringBuilder stringBuilder = new StringBuilder();
-        for (Object obj : board.get(index)) {
-            if (obj instanceof Piece) {
-                Piece piece = (Piece) obj;
-                stringBuilder.append(piece.getRepresentation());
-            }
+        for (Piece piece : board.get(index).rank) {
+            stringBuilder.append(piece.getRepresentation());
         }
         return stringBuilder.toString();
     }
 
     public void initialize() {
         pieces.clear();
-        ArrayList<Object> blackPieces = createPieces(Color.BLACK);
-        ArrayList<Object> blackPawns = createPawns(Color.BLACK);
-        ArrayList<Object> whitePawns = createPawns(Color.WHITE);
-        ArrayList<Object> whitePieces = createPieces(Color.WHITE);
+        Rank blackPieces = createPieces(Color.BLACK);
+        Rank blackPawns = createPawns(Color.BLACK);
+        Rank whitePawns = createPawns(Color.WHITE);
+        Rank whitePieces = createPieces(Color.WHITE);
 
         initialBoard();
         addPiecesToBoard(0, blackPieces);
@@ -55,58 +53,52 @@ public class Board {
         addPiecesToBoard(7, whitePieces);
     }
 
-    private ArrayList<Object> createPawns(Color color) {
-        ArrayList<Object> localPawns = new ArrayList<>();
+    private Rank createPawns(Color color) {
+        Rank localPawns = new Rank();
         for (int i = 0;i < BOARD_SIZE;i++) {
             Piece piece = createPiece(color, Type.PAWN);
             pieces.add(piece);
-            localPawns.add(piece);
+            localPawns.rank.add(piece);
         }
         return localPawns;
     }
 
-    private ArrayList<Object> createPieces(Color color) {
-        ArrayList<Object> localPieces = new ArrayList<>();
+    private Rank createPieces(Color color) {
+        Rank localPieces = new Rank();
         Type[] typeNames = new Type[]{Type.ROOK, Type.KNIGHT, Type.BISHOP, Type.QUEEN, Type.KING, Type.BISHOP, Type.KNIGHT, Type.ROOK};
         for (Type type : typeNames) {
             Piece piece = createPiece(color, type);
             pieces.add(piece);
-            localPieces.add(piece);
+            localPieces.rank.add(piece);
         }
         return localPieces;
     }
 
-    private ArrayList<Object> createEmptyRow() {
-        ArrayList<Object> empty = new ArrayList<>();
+    private Rank createEmptyRank() {
+        Rank empty = new Rank();
         for (int i = 0;i < BOARD_SIZE;i++) {
-            empty.add(".");
+            empty.rank.add(createBlank());
         }
         return empty;
     }
 
     private void initialBoard() {
         board.clear();
-        ArrayList<Object> empty = createEmptyRow();
+        Rank empty = createEmptyRank();
         for (int i = 0;i < EMPTY_ROW_NUM;i++) {
             board.add(empty);
         }
     }
 
-    private void addPiecesToBoard(int index, ArrayList<Object> pawns) {
+    private void addPiecesToBoard(int index, Rank pawns) {
         board.add(index, pawns);
     }
 
     public String showBoard() {
         StringBuilder stringBuilder = new StringBuilder();
-        for (ArrayList<Object> line: board) {
-            for (Object obj : line) {
-                if (obj instanceof Piece) {
-                    Piece pawn = (Piece) obj;
-                    stringBuilder.append(pawn.getRepresentation());
-                }
-                else {
-                    stringBuilder.append(obj);
-                }
+        for (Rank rank: board) {
+            for (Piece piece : rank.rank) {
+                stringBuilder.append(piece.getRepresentation());
             }
             appendNewLine(stringBuilder);
         }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -3,7 +3,7 @@ package softeer2nd.chess;
 import softeer2nd.chess.pieces.Piece;
 
 import java.util.ArrayList;
-렬import java.util.Comparator;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 import static softeer2nd.chess.Position.*;

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -43,10 +43,10 @@ public class Board {
 
     public void initialize() {
         pieces.clear();
-        ArrayList<Object> blackPieces = createPieces(BLACK_COLOR);
-        ArrayList<Object> blackPawns = createPawns(BLACK_COLOR, PAWN);
-        ArrayList<Object> whitePawns = createPawns(WHITE_COLOR, PAWN);
-        ArrayList<Object> whitePieces = createPieces(WHITE_COLOR);
+        ArrayList<Object> blackPieces = createPieces(Color.BLACK);
+        ArrayList<Object> blackPawns = createPawns(Color.BLACK);
+        ArrayList<Object> whitePawns = createPawns(Color.WHITE);
+        ArrayList<Object> whitePieces = createPieces(Color.WHITE);
 
         initialBoard();
         addPiecesToBoard(0, blackPieces);
@@ -55,65 +55,25 @@ public class Board {
         addPiecesToBoard(7, whitePieces);
     }
 
-    private ArrayList<Object> createPawns(String color, String name) {
+    private ArrayList<Object> createPawns(Color color) {
         ArrayList<Object> localPawns = new ArrayList<>();
         for (int i = 0;i < BOARD_SIZE;i++) {
-            Piece piece = null;
-            if (color.equals(WHITE_COLOR)) {
-                piece = createWhitePawn();
-            }
-            else if (color.equals(BLACK_COLOR)) {
-                piece = createBlackPawn();
-            }
+            Piece piece = createPiece(color, Type.PAWN);
             pieces.add(piece);
             localPawns.add(piece);
         }
         return localPawns;
     }
 
-    private ArrayList<Object> createPieces(String color) {
+    private ArrayList<Object> createPieces(Color color) {
         ArrayList<Object> localPieces = new ArrayList<>();
-        String[] piecesName = new String[]{ROOK, KNIGHT, BISHOP, QUEEN, KING, BISHOP, KNIGHT, ROOK};
-        for (String pieceName : piecesName) {
-            Piece piece = createPiece(color, pieceName);
+        Type[] typeNames = new Type[]{Type.ROOK, Type.KNIGHT, Type.BISHOP, Type.QUEEN, Type.KING, Type.BISHOP, Type.KNIGHT, Type.ROOK};
+        for (Type type : typeNames) {
+            Piece piece = createPiece(color, type);
             pieces.add(piece);
             localPieces.add(piece);
         }
         return localPieces;
-    }
-
-    private Piece createPiece(String color, String name) {
-        for (int i = 0;i < BOARD_SIZE;i++) {
-            if (color.equals(WHITE_COLOR)) {
-                switch (name) {
-                    case KING:
-                        return createWhiteKing();
-                    case QUEEN:
-                        return createWhiteQueen();
-                    case ROOK:
-                        return createWhiteRook();
-                    case BISHOP:
-                        return createWhiteBishop();
-                    case KNIGHT:
-                        return createWhiteKnight();
-                }
-            }
-            else if (color.equals(BLACK_COLOR)) {
-                switch (name) {
-                    case KING:
-                        return createBlackKing();
-                    case QUEEN:
-                        return createBlackQueen();
-                    case ROOK:
-                        return createBlackRook();
-                    case BISHOP:
-                        return createBlackBishop();
-                    case KNIGHT:
-                        return createBlackKnight();
-                }
-            }
-        }
-        return null;
     }
 
     private ArrayList<Object> createEmptyRow() {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -10,17 +10,10 @@ import static softeer2nd.utils.StringUtils.appendNewLine;
 
 public class Board {
     private static final int BOARD_SIZE = 8;
-    private static final int EMPTY_ROW_NUM = 4;
     private ArrayList<Rank> board;
-    private ArrayList<Piece> pieces;
 
     public Board() {
         board = new ArrayList<>();
-        pieces = new ArrayList<>();
-    }
-
-    public void add(Piece pawn) {
-        pieces.add(pawn);
     }
 
     public int pieceCount() {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -56,61 +56,6 @@ public class Board {
         return stringBuilder.toString();
     }
 
-    public void initialize() {
-        pieces.clear();
-        Rank blackPieces = createPiecesRank(Color.BLACK);
-        Rank blackPawns = createPawnsRank(Color.BLACK);
-        Rank whitePawns = createPawnsRank(Color.WHITE);
-        Rank whitePieces = createPiecesRank(Color.WHITE);
-
-        initialBoard();
-        addPiecesToBoard(0, blackPieces);
-        addPiecesToBoard(1, blackPawns);
-        addPiecesToBoard(6, whitePawns);
-        addPiecesToBoard(7, whitePieces);
-    }
-
-    private Rank createPawnsRank(Color color) {
-        Rank localPawns = new Rank();
-        for (int i = 0;i < BOARD_SIZE;i++) {
-            Piece piece = createPiece(color, Type.PAWN);
-            pieces.add(piece);
-            localPawns.rank.add(piece);
-        }
-        return localPawns;
-    }
-
-    private Rank createPiecesRank(Color color) {
-        Rank localPieces = new Rank();
-        Type[] typeNames = new Type[]{Type.ROOK, Type.KNIGHT, Type.BISHOP, Type.QUEEN, Type.KING, Type.BISHOP, Type.KNIGHT, Type.ROOK};
-        for (Type type : typeNames) {
-            Piece piece = createPiece(color, type);
-            pieces.add(piece);
-            localPieces.rank.add(piece);
-        }
-        return localPieces;
-    }
-
-    private Rank createEmptyRank() {
-        Rank empty = new Rank();
-        for (int i = 0;i < BOARD_SIZE;i++) {
-            empty.rank.add(createBlank());
-        }
-        return empty;
-    }
-
-    private void initialBoard() {
-        board.clear();
-        Rank empty = createEmptyRank();
-        for (int i = 0;i < EMPTY_ROW_NUM;i++) {
-            board.add(empty);
-        }
-    }
-
-    private void addPiecesToBoard(int index, Rank pawns) {
-        board.add(index, pawns);
-    }
-
     public void initialize(String boardString) {
         board.clear();
         for(int i = 0;i < BOARD_SIZE;i++) {
@@ -120,6 +65,30 @@ public class Board {
             }
             board.add(rank);
         }
+    }
+
+    public void initializeBasic() {
+        String basic = "RNBQKBNR" +
+                "PPPPPPPP" +
+                "........" +
+                "........" +
+                "........" +
+                "........" +
+                "pppppppp" +
+                "rnbqkbnr";
+        initialize(basic);
+    }
+
+    public void initializeNoPiece() {
+        String noPiece = "........" +
+                "........" +
+                "........" +
+                "........" +
+                "........" +
+                "........" +
+                "........" +
+                "........";
+        initialize(noPiece);
     }
 
     public String showBoard() {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -4,6 +4,7 @@ import softeer2nd.chess.pieces.Piece;
 
 import java.util.ArrayList;
 
+import static softeer2nd.chess.Position.*;
 import static softeer2nd.chess.pieces.Piece.*;
 import static softeer2nd.utils.StringUtils.appendNewLine;
 
@@ -34,6 +35,16 @@ public class Board {
                 .flatMap(rank -> rank.rank.stream())
                 .filter(piece -> piece.getColor().equals(color) && piece.getType().equals(type))
                 .count();
+    }
+
+    public ArrayList<Rank> getBoard() {
+        return this.board;
+    }
+
+    public Piece getPiece(String coordinate) {
+        int x = getX(coordinate.charAt(0));
+        int y = 8 - getY(coordinate.charAt(1));
+        return board.get(y).rank.get(x);
     }
 
     public String getRankResult(int index) {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -100,6 +100,17 @@ public class Board {
         board.add(index, pawns);
     }
 
+    public void initialize(String boardString) {
+        board.clear();
+        for(int i = 0;i < BOARD_SIZE;i++) {
+            Rank rank = new Rank();
+            for (int j = 0;j < BOARD_SIZE;j++) {
+                rank.rank.add(createPiece(boardString.charAt(i * BOARD_SIZE + j)));
+            }
+            board.add(rank);
+        }
+    }
+
     public String showBoard() {
         StringBuilder stringBuilder = new StringBuilder();
         for (Rank rank: board) {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -34,10 +34,15 @@ public class Board {
         return this.board;
     }
 
-제    public Piece findPiece(String coordinate) {
+    public Piece findPiece(String coordinate) {
         int x = getX(coordinate.charAt(0));
         int y = BOARD_SIZE - getY(coordinate.charAt(1));
         return board.get(y).rank.get(x);
+    }
+
+    public void move(String position, Piece piece) {
+        board.get(BOARD_SIZE - getY(position.charAt(1)))
+             .rank.set(getX(position.charAt(0)), piece);
     }
 
     public String getRankResult(int index) {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -3,6 +3,8 @@ package softeer2nd.chess;
 import softeer2nd.chess.pieces.Piece;
 
 import java.util.ArrayList;
+렬import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import static softeer2nd.chess.Position.*;
 import static softeer2nd.chess.pieces.Piece.*;
@@ -123,5 +125,21 @@ public class Board {
             }
         }
         return num;
+    }
+
+    public ArrayList<Piece> sortAscPieces(Color color) {
+        return board.stream()
+                .flatMap(rank -> rank.rank.stream())
+                .filter(piece -> piece.getColor().equals(color))
+                .sorted(Comparator.comparingDouble(Piece::getPoint))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public ArrayList<Piece> sortDescPieces(Color color) {
+        return board.stream()
+                .flatMap(rank -> rank.rank.stream())
+                .filter(piece -> piece.getColor().equals(color))
+                .sorted(Comparator.comparingDouble(Piece::getPoint).reversed())
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -34,7 +34,7 @@ public class Board {
         return this.board;
     }
 
-    public Piece getPiece(String coordinate) {
+제    public Piece findPiece(String coordinate) {
         int x = getX(coordinate.charAt(0));
         int y = BOARD_SIZE - getY(coordinate.charAt(1));
         return board.get(y).rank.get(x);

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -79,7 +79,7 @@ public class Board {
         initialize(basic);
     }
 
-    public void initializeNoPiece() {
+    public void initializeEmpty() {
         String noPiece = "........" +
                 "........" +
                 "........" +

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -99,4 +99,29 @@ public class Board {
         }
         return stringBuilder.toString();
     }
+
+    public double calculatePoint(Color color) {
+        return board.stream()
+                .flatMap(rank -> rank.rank.stream())
+                .filter(piece -> piece.getColor().equals(color))
+                .mapToDouble(Piece::getPoint)
+                .sum() - countSameLinePawn(color) * 0.5;
+    }
+
+    private int countSameLinePawn(Color color) {
+        int num = 0;
+        for (int x = 0;x < BOARD_SIZE;x++) {
+            int cnt = 0;
+            for (Rank rank : board) {
+                Piece piece = rank.rank.get(x);
+                if (piece.getType().equals(Type.PAWN) && piece.getColor().equals(color)) {
+                    cnt++;
+                }
+            }
+            if (cnt >= 2) {
+                num += cnt;
+            }
+        }
+        return num;
+    }
 }

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -41,10 +41,10 @@ public class Board {
 
     public void initialize() {
         pieces.clear();
-        Rank blackPieces = createPieces(Color.BLACK);
-        Rank blackPawns = createPawns(Color.BLACK);
-        Rank whitePawns = createPawns(Color.WHITE);
-        Rank whitePieces = createPieces(Color.WHITE);
+        Rank blackPieces = createPiecesRank(Color.BLACK);
+        Rank blackPawns = createPawnsRank(Color.BLACK);
+        Rank whitePawns = createPawnsRank(Color.WHITE);
+        Rank whitePieces = createPiecesRank(Color.WHITE);
 
         initialBoard();
         addPiecesToBoard(0, blackPieces);
@@ -53,7 +53,7 @@ public class Board {
         addPiecesToBoard(7, whitePieces);
     }
 
-    private Rank createPawns(Color color) {
+    private Rank createPawnsRank(Color color) {
         Rank localPawns = new Rank();
         for (int i = 0;i < BOARD_SIZE;i++) {
             Piece piece = createPiece(color, Type.PAWN);
@@ -63,7 +63,7 @@ public class Board {
         return localPawns;
     }
 
-    private Rank createPieces(Color color) {
+    private Rank createPiecesRank(Color color) {
         Rank localPieces = new Rank();
         Type[] typeNames = new Type[]{Type.ROOK, Type.KNIGHT, Type.BISHOP, Type.QUEEN, Type.KING, Type.BISHOP, Type.KNIGHT, Type.ROOK};
         for (Type type : typeNames) {

--- a/src/main/java/softeer2nd/chess/Board.java
+++ b/src/main/java/softeer2nd/chess/Board.java
@@ -43,7 +43,7 @@ public class Board {
 
     public Piece getPiece(String coordinate) {
         int x = getX(coordinate.charAt(0));
-        int y = 8 - getY(coordinate.charAt(1));
+        int y = BOARD_SIZE - getY(coordinate.charAt(1));
         return board.get(y).rank.get(x);
     }
 

--- a/src/main/java/softeer2nd/chess/Position.java
+++ b/src/main/java/softeer2nd/chess/Position.java
@@ -1,0 +1,11 @@
+package softeer2nd.chess;
+
+public class Position {
+    public static int getX(char x) {
+        return x - 'a';
+    }
+
+    public static int getY(char y) {
+        return Character.getNumericValue(y);
+    }
+}

--- a/src/main/java/softeer2nd/chess/Rank.java
+++ b/src/main/java/softeer2nd/chess/Rank.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess;
+
+import softeer2nd.chess.pieces.Piece;
+
+import java.util.ArrayList;
+
+public class Rank {
+    public final ArrayList<Piece> rank = new ArrayList<>();
+}

--- a/src/main/java/softeer2nd/chess/pieces/Bishop.java
+++ b/src/main/java/softeer2nd/chess/pieces/Bishop.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class Bishop extends Piece {
+    private Bishop(Color color) {
+        super(color, Type.BISHOP);
+    }
+
+    public static Bishop createWhiteBishop() {
+        return new Bishop(Color.WHITE);
+    }
+    public static Bishop createBlackBishop() {
+        return new Bishop(Color.BLACK);
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/King.java
+++ b/src/main/java/softeer2nd/chess/pieces/King.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class King extends Piece{
+    private King(Color color) {
+        super(color, Type.KING);
+    }
+
+    public static King createWhiteKing() {
+        return new King(Color.WHITE);
+    }
+    public static King createBlackKing() {
+        return new King(Color.BLACK);
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/Knight.java
+++ b/src/main/java/softeer2nd/chess/pieces/Knight.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class Knight extends Piece {
+    private Knight(Color color) {
+        super(color, Type.KNIGHT);
+    }
+
+    public static Knight createWhiteKnight() {
+        return new Knight(Color.WHITE);
+    }
+    public static Knight createBlackKnight() {
+        return new Knight(Color.BLACK);
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/pieces/Pawn.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class Pawn extends Piece {
+    private Pawn(Color color) {
+        super(color, Type.PAWN);
+    }
+
+    public static Pawn createWhitePawn() {
+        return new Pawn(Color.WHITE);
+    }
+    public static Pawn createBlackPawn() {
+        return new Pawn(Color.BLACK);
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -36,87 +36,27 @@ public class Piece {
         this.type = type;
     }
 
-        if (color.equals(WHITE_COLOR)) {
-            switch (name) {
-                case KING:
-                    this.representation = WHITE_KING_REPRESENTATION;
-                    break;
-                case QUEEN:
-                    this.representation = WHITE_QUEEN_REPRESENTATION;
-                    break;
-                case ROOK:
-                    this.representation = WHITE_ROOK_REPRESENTATION;
-                    break;
-                case BISHOP:
-                    this.representation = WHITE_BISHOP_REPRESENTATION;
-                    break;
-                case KNIGHT:
-                    this.representation = WHITE_KNIGHT_REPRESENTATION;
-                    break;
-                case PAWN:
-                    this.representation = WHITE_PAWN_REPRESENTATION;
-                    break;
-            }
+    public static Piece createBlank() {
+        return new Piece();
+    }
 
-        } else if (color.equals(BLACK_COLOR)) {
-            switch (name) {
-                case KING:
-                    this.representation = BLACK_KING_REPRESENTATION;
-                    break;
-                case QUEEN:
-                    this.representation = BLACK_QUEEN_REPRESENTATION;
-                    break;
-                case ROOK:
-                    this.representation = BLACK_ROOK_REPRESENTATION;
-                    break;
-                case BISHOP:
-                    this.representation = BLACK_BISHOP_REPRESENTATION;
-                    break;
-                case KNIGHT:
-                    this.representation = BLACK_KNIGHT_REPRESENTATION;
-                    break;
-                case PAWN:
-                    this.representation = BLACK_PAWN_REPRESENTATION;
-                    break;
-            }
+    public static Piece createPiece(Color color, Type type) {
+        switch (type) {
+            case KING:
+                return color.equals(Color.WHITE) ? King.createWhiteKing() : King.createBlackKing();
+            case QUEEN:
+                return color.equals(Color.WHITE) ? Queen.createWhiteQueen() : Queen.createBlackQueen();
+            case ROOK:
+                return color.equals(Color.WHITE) ? Rook.createWhiteRook() : Rook.createBlackRook();
+            case BISHOP:
+                return color.equals(Color.WHITE) ? Bishop.createWhiteBishop() : Bishop.createBlackBishop();
+            case KNIGHT:
+                return color.equals(Color.WHITE) ? Knight.createWhiteKnight() : Knight.createBlackKnight();
+            case PAWN:
+                return color.equals(Color.WHITE) ? Pawn.createWhitePawn() : Pawn.createBlackPawn();
+            default:
+                throw new IllegalArgumentException("색깔과 종류가 적절하지 않습니다.");
         }
-    }
-
-    public static Piece createWhiteKing() {
-        return new Piece(WHITE_COLOR, KING);
-    }
-    public static Piece createBlackKing() {
-        return new Piece(BLACK_COLOR, KING);
-    }
-    public static Piece createWhiteQueen() {
-        return new Piece(WHITE_COLOR, QUEEN);
-    }
-    public static Piece createBlackQueen() {
-        return new Piece(BLACK_COLOR, QUEEN);
-    }
-    public static Piece createWhiteRook() {
-        return new Piece(WHITE_COLOR, ROOK);
-    }
-    public static Piece createBlackRook() {
-        return new Piece(BLACK_COLOR, ROOK);
-    }
-    public static Piece createWhiteBishop() {
-        return new Piece(WHITE_COLOR, BISHOP);
-    }
-    public static Piece createBlackBishop() {
-        return new Piece(BLACK_COLOR, BISHOP);
-    }
-    public static Piece createWhiteKnight() {
-        return new Piece(WHITE_COLOR, KNIGHT);
-    }
-    public static Piece createBlackKnight() {
-        return new Piece(BLACK_COLOR, KNIGHT);
-    }
-    public static Piece createWhitePawn() {
-        return new Piece(WHITE_COLOR, PAWN);
-    }
-    public static Piece createBlackPawn() {
-        return new Piece(BLACK_COLOR, PAWN);
     }
 
     public boolean isBlack() {

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -6,12 +6,19 @@ public class Piece {
     }
 
     public enum Type {
-        PAWN('p'), ROOK('r'), KNIGHT('n'), BISHOP('b'),
-        QUEEN('q'), KING('k'), NO_PIECE('.');
+        PAWN('p', 1.0),
+        ROOK('r', 5.0),
+        KNIGHT('n', 2.5),
+        BISHOP('b', 3),
+        QUEEN('q', 9),
+        KING('k', 0.0),
+        NO_PIECE('.', 0.0);
 
-        private char representation;
-        Type(char representation) {
+        private final char representation;
+        private final double defaultPoint;
+        Type(char representation, double defaultPoint) {
             this.representation = representation;
+            this.defaultPoint = defaultPoint;
         }
 
         public char getWhiteRepresentation() {
@@ -123,5 +130,8 @@ public class Piece {
             default:
                 throw new IllegalArgumentException("색깔이 적절하지 않습니다.");
         }
+    }
+    public double getPoint() {
+        return type.defaultPoint;
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -60,16 +60,27 @@ public class Piece {
     }
 
     public boolean isBlack() {
-        return this.color.equals(BLACK_COLOR);
+        return this.color.equals(Color.BLACK);
     }
     public boolean isWhite() {
-        return this.color.equals(WHITE_COLOR);
+        return this.color.equals(Color.WHITE);
     }
 
-    public String getColor() {
+    public Color getColor() {
         return this.color;
     }
+    public Type getType() {
+        return this.type;
+    }
     public char getRepresentation() {
-        return this.representation;
+        switch (this.color) {
+            case WHITE:
+            case NO_COLOR:
+                return type.getWhiteRepresentation();
+            case BLACK:
+                return type.getBlackRepresentation();
+            default:
+                throw new IllegalArgumentException("색깔이 적절하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -7,7 +7,7 @@ public class Piece {
 
     public enum Type {
         PAWN('p'), ROOK('r'), KNIGHT('n'), BISHOP('b'),
-        QUEEN('q'), KING('k'), NO_PIECE('o');
+        QUEEN('q'), KING('k'), NO_PIECE('.');
 
         private char representation;
         Type(char representation) {

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -9,8 +9,8 @@ public class Piece {
         PAWN('p', 1.0),
         ROOK('r', 5.0),
         KNIGHT('n', 2.5),
-        BISHOP('b', 3),
-        QUEEN('q', 9),
+        BISHOP('b', 3.0),
+        QUEEN('q', 9.0),
         KING('k', 0.0),
         NO_PIECE('.', 0.0);
 

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -41,21 +41,51 @@ public class Piece {
     }
 
     public static Piece createPiece(Color color, Type type) {
+        switch (color) {
+            case WHITE:
+                return createWhite(type);
+            case BLACK:
+                return createBlack(type);
+            default:
+                throw new IllegalArgumentException("색깔이 적절하지 않습니다.");
+        }
+    }
+
+    private static Piece createWhite(Type type) {
         switch (type) {
             case KING:
-                return color.equals(Color.WHITE) ? King.createWhiteKing() : King.createBlackKing();
+                return King.createWhiteKing();
             case QUEEN:
-                return color.equals(Color.WHITE) ? Queen.createWhiteQueen() : Queen.createBlackQueen();
+                return Queen.createWhiteQueen();
             case ROOK:
-                return color.equals(Color.WHITE) ? Rook.createWhiteRook() : Rook.createBlackRook();
+                return Rook.createWhiteRook();
             case BISHOP:
-                return color.equals(Color.WHITE) ? Bishop.createWhiteBishop() : Bishop.createBlackBishop();
+                return Bishop.createWhiteBishop();
             case KNIGHT:
-                return color.equals(Color.WHITE) ? Knight.createWhiteKnight() : Knight.createBlackKnight();
+                return Knight.createWhiteKnight();
             case PAWN:
-                return color.equals(Color.WHITE) ? Pawn.createWhitePawn() : Pawn.createBlackPawn();
+                return Pawn.createWhitePawn();
             default:
-                throw new IllegalArgumentException("색깔과 종류가 적절하지 않습니다.");
+                throw new IllegalArgumentException("백색 기물 생성: 종류가 적절하지 않습니다.");
+        }
+    }
+
+    private static Piece createBlack(Type type) {
+        switch (type) {
+            case KING:
+                return King.createBlackKing();
+            case QUEEN:
+                return Queen.createBlackQueen();
+            case ROOK:
+                return Rook.createBlackRook();
+            case BISHOP:
+                return Bishop.createBlackBishop();
+            case KNIGHT:
+                return Knight.createBlackKnight();
+            case PAWN:
+                return Pawn.createBlackPawn();
+            default:
+                throw new IllegalArgumentException("흑색 기물 생성: 종류가 적절하지 않습니다.");
         }
     }
 

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -51,6 +51,17 @@ public class Piece {
         }
     }
 
+    public static Piece createPiece(char representation) {
+        boolean isBlack = Character.isUpperCase(representation);
+        representation = Character.toLowerCase(representation);
+        for (Type type : Type.values()) {
+            if (representation == type.representation) {
+                return type == Type.NO_PIECE ? createBlank() : createPiece(isBlack ? Color.BLACK : Color.WHITE, type);
+            }
+        }
+        throw new IllegalArgumentException("잘못된 식별 문자 입니다");
+    }
+
     private static Piece createWhite(Type type) {
         switch (type) {
             case KING:

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -1,30 +1,30 @@
 package softeer2nd.chess.pieces;
 
 public class Piece {
-    public static final String WHITE_COLOR = "white";
-    public static final String BLACK_COLOR = "black";
-    public static final String KING = "King";
-    public static final char WHITE_KING_REPRESENTATION = 'k';
-    public static final char BLACK_KING_REPRESENTATION = 'K';
-    public static final String QUEEN = "Queen";
-    public static final char WHITE_QUEEN_REPRESENTATION = 'q';
-    public static final char BLACK_QUEEN_REPRESENTATION = 'Q';
-    public static final String ROOK = "Rook";
-    public static final char WHITE_ROOK_REPRESENTATION = 'r';
-    public static final char BLACK_ROOK_REPRESENTATION = 'R';
-    public static final String BISHOP = "Bishop";
-    public static final char WHITE_BISHOP_REPRESENTATION = 'b';
-    public static final char BLACK_BISHOP_REPRESENTATION = 'B';
-    public static final String KNIGHT = "Knight";
-    public static final char WHITE_KNIGHT_REPRESENTATION = 'n';
-    public static final char BLACK_KNIGHT_REPRESENTATION = 'N';
-    public static final String PAWN = "Pawn";
-    public static final char WHITE_PAWN_REPRESENTATION = 'p';
-    public static final char BLACK_PAWN_REPRESENTATION = 'P';
+    public enum Color {
+        WHITE, BLACK, NO_COLOR;
+    }
 
-    private String color;
-    private String name;
-    private char representation;
+    public enum Type {
+        PAWN('p'), ROOK('r'), KNIGHT('n'), BISHOP('b'),
+        QUEEN('q'), KING('k'), NO_PIECE('o');
+
+        private char representation;
+        Type(char representation) {
+            this.representation = representation;
+        }
+
+        public char getWhiteRepresentation() {
+            return this.representation;
+        }
+
+        public char getBlackRepresentation() {
+            return Character.toUpperCase(this.representation);
+        }
+    }
+
+    private Color color;
+    private Type type;
 
     private Piece(String color, String name) {
         this.color = color;

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -1,5 +1,7 @@
 package softeer2nd.chess.pieces;
 
+import java.util.Objects;
+
 public class Piece {
     public enum Color {
         WHITE, BLACK, NO_COLOR;
@@ -133,5 +135,19 @@ public class Piece {
     }
     public double getPoint() {
         return type.defaultPoint;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Piece piece = (Piece) o;
+        return color.equals(piece.getColor()) &&
+                type.equals(piece.getType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(color, type);
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -26,9 +26,15 @@ public class Piece {
     private Color color;
     private Type type;
 
-    private Piece(String color, String name) {
+    private Piece() {
+        this.color = Color.NO_COLOR;
+        this.type = Type.NO_PIECE;
+    }
+
+    protected Piece(Color color, Type type) {
         this.color = color;
-        this.name = name;
+        this.type = type;
+    }
 
         if (color.equals(WHITE_COLOR)) {
             switch (name) {

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -23,8 +23,8 @@ public class Piece {
         }
     }
 
-    private Color color;
-    private Type type;
+    private final Color color;
+    private final Type type;
 
     private Piece() {
         this.color = Color.NO_COLOR;

--- a/src/main/java/softeer2nd/chess/pieces/Queen.java
+++ b/src/main/java/softeer2nd/chess/pieces/Queen.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class Queen extends Piece {
+    private Queen(Color color) {
+        super(color, Type.QUEEN);
+    }
+
+    public static Queen createWhiteQueen() {
+        return new Queen(Color.WHITE);
+    }
+    public static Queen createBlackQueen() {
+        return new Queen(Color.BLACK);
+    }
+}

--- a/src/main/java/softeer2nd/chess/pieces/Rook.java
+++ b/src/main/java/softeer2nd/chess/pieces/Rook.java
@@ -1,0 +1,14 @@
+package softeer2nd.chess.pieces;
+
+public class Rook extends Piece {
+    private Rook(Color color) {
+        super(color, Type.ROOK);
+    }
+
+    public static Rook createWhiteRook() {
+        return new Rook(Color.WHITE);
+    }
+    public static Rook createBlackRook() {
+        return new Rook(Color.BLACK);
+    }
+}

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -6,10 +6,19 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static softeer2nd.utils.StringUtils.appendNewLine;
+import static softeer2nd.chess.pieces.Piece.*;
 
 class BoardTest {
 
     private Board board;
+    private String sample = ".KR....." +
+                            "P.PB...." +
+                            ".P..Q..." +
+                            "........" +
+                            ".....nq." +
+                            ".....p.." +
+                            "......p." +
+                            "....rk..";
 
     @BeforeEach
     public void setup() {
@@ -17,10 +26,9 @@ class BoardTest {
     }
 
     @Test
-    @DisplayName("Board 초기화 검증")
-    public void create() {
+    @DisplayName("Board를 초기화할 수 있어야 한다")
+    public void initialize() {
         board.initialize();
-        assertEquals(32, board.pieceCount());
         String blackRank = appendNewLine("........");
         assertEquals(
                 appendNewLine("RNBQKBNR") +
@@ -30,5 +38,39 @@ class BoardTest {
                         appendNewLine("rnbqkbnr"),
                 board.showBoard()
         );
+    }
+
+    @Test
+    @DisplayName("Board의 특정한 상태로 초기화할 수 있어야 한다")
+    public void initializeState() {
+        String boardString = ".KR.....\n" +
+                "P.PB....\n" +
+                ".P..Q...\n" +
+                "........\n" +
+                ".....nq.\n" +
+                ".....p..\n" +
+                "......p.\n" +
+                "....rk..\n";
+        board.initialize(sample);
+        assertEquals(boardString, board.showBoard());
+    }
+
+    @Test
+    @DisplayName("모든 기물의 개수를 반환할 수 있어야 한다")
+    public void getPieceCount() {
+        board.initialize();
+        assertEquals(32, board.pieceCount());
+
+        board.initialize(sample);
+        assertEquals(13, board.pieceCount());
+    }
+
+    @Test
+    @DisplayName("기물의 색과 종류를 인자로 받아 해당 기물의 개수를 반환할 수 있어야 한다")
+    public void getPieceCountWithColorAndType() {
+        board.initialize();
+        assertEquals(8, board.pieceCount(Color.WHITE, Type.PAWN));
+        assertEquals(2, board.pieceCount(Color.BLACK, Type.ROOK));
+        assertEquals(1, board.pieceCount(Color.BLACK, Type.QUEEN));
     }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import softeer2nd.chess.pieces.Piece;
+import softeer2nd.chess.pieces.*;
+
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static softeer2nd.utils.StringUtils.appendNewLine;
@@ -172,5 +174,33 @@ class BoardTest {
         assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
 
         System.out.println(board.showBoard());
+    }
+
+    @Test
+    @DisplayName("기물의 점수가 낮은 순으로 정렬할 수 있어야 한다")
+    public void sortAscPieces() {
+        board.initialize(noSameLinePawn);
+
+        ArrayList<Piece> sortAscBlackPieces = board.sortAscPieces(Color.BLACK);
+        ArrayList<Piece> sortAscWhitePieces = board.sortAscPieces(Color.WHITE);
+
+        assertEquals(King.createBlackKing(), sortAscBlackPieces.get(0));
+        assertEquals(Queen.createBlackQueen(), sortAscBlackPieces.get(sortAscBlackPieces.size() - 1));
+        assertEquals(Pawn.createWhitePawn(), sortAscWhitePieces.get(1));
+        assertEquals(Rook.createWhiteRook(), sortAscWhitePieces.get(sortAscWhitePieces.size() - 2));
+    }
+
+    @Test
+    @DisplayName("기물의 점수가 높은 순으로 정렬할 수 있어야 한다")
+    public void sortDescPieces() {
+        board.initialize(yesSameLinePawn);
+
+        ArrayList<Piece> sortDescBlackPieces = board.sortDescPieces(Color.BLACK);
+        ArrayList<Piece> sortDescWhitePieces = board.sortDescPieces(Color.WHITE);
+
+        assertEquals(Queen.createBlackQueen(), sortDescBlackPieces.get(0));
+        assertEquals(King.createBlackKing(), sortDescBlackPieces.get(sortDescBlackPieces.size() - 1));
+        assertEquals(Rook.createWhiteRook(), sortDescWhitePieces.get(1));
+        assertEquals(Pawn.createWhitePawn(), sortDescWhitePieces.get(sortDescWhitePieces.size() - 2));
     }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -120,4 +120,57 @@ class BoardTest {
         assertEquals(piece, board.findPiece(position));
         System.out.println(board.showBoard());
     }
+
+    @Test
+    @DisplayName("같은 세로줄에 같은 색의 폰이 없는 경우의 점수를 계산할 수 있다")
+    public void calculatePointNoSameLinePawn() {
+        String boardString = ".KR....." +
+                "P.PB...." +
+                ".P..Q..." +
+                "........" +
+                ".....nq." +
+                ".....p.p" +
+                "......p." +
+                "....rk..";
+        board.initialize(boardString);
+        assertEquals(20, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.01);
+    }
+
+    @Test
+    @DisplayName("같은 세로줄에 같은 색의 폰이 있는 경우의 점수를 계산할 수 있다")
+    public void calculatePointYesSameLinePawn() {
+        String boardString = ".KR....." +
+                "P.PB...." +
+                ".P..Q..." +
+                "........" +
+                ".....nq." +
+                ".....p.p" +
+                ".....pp." +
+                "....rk..";
+        board.initialize(boardString);
+        assertEquals(20, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.01);
+    }
+
+    @Test
+    @DisplayName("특정 상태의 체스판의 점수를 계산할 수 있다")
+    public void calculatePoint() {
+        board.initializeEmpty();
+
+        board.move("b6", createPiece(Color.BLACK, Type.PAWN));
+        board.move("e6", createPiece(Color.BLACK, Type.QUEEN));
+        board.move("b8", createPiece(Color.BLACK, Type.KING));
+        board.move("c8", createPiece(Color.BLACK, Type.ROOK));
+
+        board.move("f2", createPiece(Color.WHITE, Type.PAWN));
+        board.move("g2", createPiece(Color.WHITE, Type.PAWN));
+        board.move("e1", createPiece(Color.WHITE, Type.ROOK));
+        board.move("f1", createPiece(Color.WHITE, Type.KING));
+
+        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
+
+        System.out.println(board.showBoard());
+    }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -73,4 +73,12 @@ class BoardTest {
         assertEquals(2, board.pieceCount(Color.BLACK, Type.ROOK));
         assertEquals(1, board.pieceCount(Color.BLACK, Type.QUEEN));
     }
+
+    @Test
+    @DisplayName("좌표를 인자로 받아 해당 좌표의 기물을 조회할 수 있어야 한다")
+    public void getPieceWithCoordinate() {
+        board.initialize();
+        assertEquals(board.getBoard().get(0).rank.get(0), board.getPiece("a8"));
+        assertEquals(board.getBoard().get(7).rank.get(4), board.getPiece("e1"));
+    }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -29,6 +29,22 @@ class BoardTest {
                             "........" +
                             "........" +
                             "........";
+    private String noSameLinePawn = ".KR....." +
+            "P.PB...." +
+            ".P..Q..." +
+            "........" +
+            ".....nq." +
+            ".....p.p" +
+            "......p." +
+            "....rk..";
+    private String yesSameLinePawn = ".KR....." +
+            "P.PB...." +
+            ".P..Q..." +
+            "........" +
+            ".....nq." +
+            ".....p.p" +
+            ".....pp." +
+            "....rk..";
 
     @BeforeEach
     public void setup() {
@@ -124,15 +140,7 @@ class BoardTest {
     @Test
     @DisplayName("같은 세로줄에 같은 색의 폰이 없는 경우의 점수를 계산할 수 있다")
     public void calculatePointNoSameLinePawn() {
-        String boardString = ".KR....." +
-                "P.PB...." +
-                ".P..Q..." +
-                "........" +
-                ".....nq." +
-                ".....p.p" +
-                "......p." +
-                "....rk..";
-        board.initialize(boardString);
+        board.initialize(noSameLinePawn);
         assertEquals(20, board.calculatePoint(Color.BLACK), 0.01);
         assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.01);
     }
@@ -140,15 +148,7 @@ class BoardTest {
     @Test
     @DisplayName("같은 세로줄에 같은 색의 폰이 있는 경우의 점수를 계산할 수 있다")
     public void calculatePointYesSameLinePawn() {
-        String boardString = ".KR....." +
-                "P.PB...." +
-                ".P..Q..." +
-                "........" +
-                ".....nq." +
-                ".....p.p" +
-                ".....pp." +
-                "....rk..";
-        board.initialize(boardString);
+        board.initialize(yesSameLinePawn);
         assertEquals(20, board.calculatePoint(Color.BLACK), 0.01);
         assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.01);
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import softeer2nd.chess.pieces.Piece;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static softeer2nd.utils.StringUtils.appendNewLine;
 import static softeer2nd.chess.pieces.Piece.*;

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -102,7 +102,20 @@ class BoardTest {
     @DisplayName("좌표를 인자로 받아 해당 좌표의 기물을 조회할 수 있어야 한다")
     public void getPieceWithCoordinate() {
         board.initializeBasic();
-        assertEquals(board.getBoard().get(0).rank.get(0), board.getPiece("a8"));
-        assertEquals(board.getBoard().get(7).rank.get(4), board.getPiece("e1"));
+        assertEquals(board.getBoard().get(0).rank.get(0), board.findPiece("a8"));
+        assertEquals(board.getBoard().get(7).rank.get(4), board.findPiece("e1"));
+    }
+
+    @Test
+    @DisplayName("좌표와 기물을 인자로 받아 해당 좌표로 해당 기물을 이동할 수 있어야 한다")
+    public void move() {
+        board.initializeEmpty();
+
+        String position = "b5";
+        Piece piece = createPiece(Color.BLACK, Type.ROOK);
+        board.move(position, piece);
+
+        assertEquals(piece, board.findPiece(position));
+        System.out.println(board.showBoard());
     }
 }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -11,7 +11,7 @@ import static softeer2nd.chess.pieces.Piece.*;
 class BoardTest {
 
     private Board board;
-    private String sample = ".KR....." +
+    private String sample1 = ".KR....." +
                             "P.PB...." +
                             ".P..Q..." +
                             "........" +
@@ -19,6 +19,14 @@ class BoardTest {
                             ".....p.." +
                             "......p." +
                             "....rk..";
+    private String sample2 = "........" +
+                            "........" +
+                            "........" +
+                            "........" +
+                            "........" +
+                            "........" +
+                            "........" +
+                            "........";
 
     @BeforeEach
     public void setup() {
@@ -28,7 +36,7 @@ class BoardTest {
     @Test
     @DisplayName("Board를 초기화할 수 있어야 한다")
     public void initialize() {
-        board.initialize();
+        board.initializeBasic();
         String blackRank = appendNewLine("........");
         assertEquals(
                 appendNewLine("RNBQKBNR") +
@@ -38,10 +46,15 @@ class BoardTest {
                         appendNewLine("rnbqkbnr"),
                 board.showBoard()
         );
+
+        board.initializeNoPiece();
+        assertEquals(blackRank + blackRank + blackRank + blackRank +
+                blackRank + blackRank + blackRank + blackRank,
+                board.showBoard());
     }
 
     @Test
-    @DisplayName("Board의 특정한 상태로 초기화할 수 있어야 한다")
+    @DisplayName("Board를 입력받는 String을 사용해 초기화할 수 있어야 한다")
     public void initializeState() {
         String boardString = ".KR.....\n" +
                 "P.PB....\n" +
@@ -51,24 +64,35 @@ class BoardTest {
                 ".....p..\n" +
                 "......p.\n" +
                 "....rk..\n";
-        board.initialize(sample);
+        board.initialize(sample1);
         assertEquals(boardString, board.showBoard());
+
+        String noPiece = "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n" +
+                "........\n";
+        board.initialize(sample2);
+        assertEquals(noPiece, board.showBoard());
     }
 
     @Test
     @DisplayName("모든 기물의 개수를 반환할 수 있어야 한다")
     public void getPieceCount() {
-        board.initialize();
+        board.initializeBasic();
         assertEquals(32, board.pieceCount());
 
-        board.initialize(sample);
+        board.initialize(sample1);
         assertEquals(13, board.pieceCount());
     }
 
     @Test
     @DisplayName("기물의 색과 종류를 인자로 받아 해당 기물의 개수를 반환할 수 있어야 한다")
     public void getPieceCountWithColorAndType() {
-        board.initialize();
+        board.initializeBasic();
         assertEquals(8, board.pieceCount(Color.WHITE, Type.PAWN));
         assertEquals(2, board.pieceCount(Color.BLACK, Type.ROOK));
         assertEquals(1, board.pieceCount(Color.BLACK, Type.QUEEN));
@@ -77,7 +101,7 @@ class BoardTest {
     @Test
     @DisplayName("좌표를 인자로 받아 해당 좌표의 기물을 조회할 수 있어야 한다")
     public void getPieceWithCoordinate() {
-        board.initialize();
+        board.initializeBasic();
         assertEquals(board.getBoard().get(0).rank.get(0), board.getPiece("a8"));
         assertEquals(board.getBoard().get(7).rank.get(4), board.getPiece("e1"));
     }

--- a/src/test/java/softeer2nd/chess/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/BoardTest.java
@@ -47,7 +47,7 @@ class BoardTest {
                 board.showBoard()
         );
 
-        board.initializeNoPiece();
+        board.initializeEmpty();
         assertEquals(blackRank + blackRank + blackRank + blackRank +
                 blackRank + blackRank + blackRank + blackRank,
                 board.showBoard());

--- a/src/test/java/softeer2nd/chess/PositionTest.java
+++ b/src/test/java/softeer2nd/chess/PositionTest.java
@@ -1,0 +1,24 @@
+package softeer2nd.chess;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static softeer2nd.chess.Position.*;
+
+class PositionTest {
+
+    @Test
+    @DisplayName("char 알파벳을 입력받아 int로 반환할 수 있어야 한다")
+    public void charAlphabetToInt() {
+        assertEquals(0, getX('a'));
+        assertEquals(5, getX('f'));
+    }
+
+    @Test
+    @DisplayName("char 숫자를 입력받아 int로 반환할 수 있어야 한다")
+    public void charNumToInt() {
+        assertEquals(0, getY('0'));
+        assertEquals(5, getY('5'));
+    }
+}

--- a/src/test/java/softeer2nd/chess/pieces/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/pieces/PieceTest.java
@@ -48,6 +48,8 @@ class PieceTest {
         verifyBlackPiece(createPiece(Color.BLACK, Type.BISHOP));
         verifyBlackPiece(createPiece(Color.BLACK, Type.KNIGHT));
         verifyBlackPiece(createPiece(Color.BLACK, Type.PAWN));
+
+        verifyBlank(createBlank());
     }
 
     private void verifyWhitePiece(final Piece piece) {
@@ -57,6 +59,11 @@ class PieceTest {
     private void verifyBlackPiece(final Piece piece) {
         assertTrue(piece.isBlack());
         assertFalse(piece.isWhite());
+    }
+    private void verifyBlank(final Piece piece) {
+        assertFalse(piece.isWhite());
+        assertFalse(piece.isBlack());
+        assertEquals(Type.NO_PIECE, piece.getType());
     }
 
     @Test

--- a/src/test/java/softeer2nd/chess/pieces/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/pieces/PieceTest.java
@@ -9,42 +9,45 @@ import static softeer2nd.chess.pieces.Piece.*;
 class PieceTest {
 
     @Test
-    @DisplayName("기물 생성")
+    @DisplayName("색과 종류를 입력받아 기물을 생성할 수 있어야 한다")
     public void create() {
-        verifyPiece(Piece.createWhiteKing(), WHITE_COLOR, WHITE_KING_REPRESENTATION);
-        verifyPiece(Piece.createBlackKing(), BLACK_COLOR, BLACK_KING_REPRESENTATION);
-        verifyPiece(Piece.createWhiteQueen(), WHITE_COLOR, WHITE_QUEEN_REPRESENTATION);
-        verifyPiece(Piece.createBlackQueen(), BLACK_COLOR, BLACK_QUEEN_REPRESENTATION);
-        verifyPiece(Piece.createWhiteRook(), WHITE_COLOR, WHITE_ROOK_REPRESENTATION);
-        verifyPiece(Piece.createBlackRook(), BLACK_COLOR, BLACK_ROOK_REPRESENTATION);
-        verifyPiece(Piece.createWhiteBishop(), WHITE_COLOR, WHITE_BISHOP_REPRESENTATION);
-        verifyPiece(Piece.createBlackBishop(), BLACK_COLOR, BLACK_BISHOP_REPRESENTATION);
-        verifyPiece(Piece.createWhiteKnight(), WHITE_COLOR, WHITE_KNIGHT_REPRESENTATION);
-        verifyPiece(Piece.createBlackKnight(), BLACK_COLOR, BLACK_KNIGHT_REPRESENTATION);
-        verifyPiece(Piece.createWhitePawn(), WHITE_COLOR, WHITE_PAWN_REPRESENTATION);
-        verifyPiece(Piece.createBlackPawn(), BLACK_COLOR, BLACK_PAWN_REPRESENTATION);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.KING), Color.WHITE, Type.KING);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.KING), Color.BLACK, Type.KING);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.QUEEN), Color.WHITE, Type.QUEEN);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.QUEEN), Color.BLACK, Type.QUEEN);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.ROOK), Color.WHITE, Type.ROOK);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.ROOK), Color.BLACK, Type.ROOK);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.BISHOP), Color.WHITE, Type.BISHOP);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.BISHOP), Color.BLACK, Type.BISHOP);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.KNIGHT), Color.WHITE, Type.KNIGHT);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.KNIGHT), Color.BLACK, Type.KNIGHT);
+        verifyCreatePiece(createPiece(Color.WHITE, Type.PAWN), Color.WHITE, Type.PAWN);
+        verifyCreatePiece(createPiece(Color.BLACK, Type.PAWN), Color.BLACK, Type.PAWN);
+        verifyCreatePiece(createBlank(), Color.NO_COLOR, Type.NO_PIECE);
     }
 
-    private void verifyPiece(final Piece piece, final String color, final char representation) {
+    private void verifyCreatePiece(final Piece piece, final Color color, final Type type) {
         assertEquals(color, piece.getColor());
-        assertEquals(representation, piece.getRepresentation());
+        assertEquals(type, piece.getType());
+        assertEquals(type.getWhiteRepresentation(), piece.getType().getWhiteRepresentation());
+        assertEquals(type.getBlackRepresentation(), piece.getType().getBlackRepresentation());
     }
 
     @Test
-    @DisplayName("기물 색깔 검증")
+    @DisplayName("색과 종류를 입력받아 생성된 기물의 색깔을 확인할 수 있어야 한다")
     public void color() {
-        verifyWhitePiece(createWhiteKing());
-        verifyWhitePiece(createWhiteQueen());
-        verifyWhitePiece(createWhiteRook());
-        verifyWhitePiece(createWhiteBishop());
-        verifyWhitePiece(createWhiteKnight());
-        verifyWhitePiece(createWhitePawn());
-        verifyBlackPiece(createBlackKing());
-        verifyBlackPiece(createBlackQueen());
-        verifyBlackPiece(createBlackRook());
-        verifyBlackPiece(createBlackBishop());
-        verifyBlackPiece(createBlackKnight());
-        verifyBlackPiece(createBlackPawn());
+        verifyWhitePiece(createPiece(Color.WHITE, Type.KING));
+        verifyWhitePiece(createPiece(Color.WHITE, Type.QUEEN));
+        verifyWhitePiece(createPiece(Color.WHITE, Type.ROOK));
+        verifyWhitePiece(createPiece(Color.WHITE, Type.BISHOP));
+        verifyWhitePiece(createPiece(Color.WHITE, Type.KNIGHT));
+        verifyWhitePiece(createPiece(Color.WHITE, Type.PAWN));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.KING));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.QUEEN));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.ROOK));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.BISHOP));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.KNIGHT));
+        verifyBlackPiece(createPiece(Color.BLACK, Type.PAWN));
     }
 
     private void verifyWhitePiece(final Piece piece) {

--- a/src/test/java/softeer2nd/chess/pieces/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/pieces/PieceTest.java
@@ -59,4 +59,18 @@ class PieceTest {
         assertFalse(piece.isWhite());
     }
 
+    @Test
+    @DisplayName("흰색 기물일 때는 소문자, 검은색 기물일 때는 대문자 식별 문자가 출력되어야 한다")
+    public void getRepresentationPerPiece() {
+        Piece whitePawn = createPiece(Color.WHITE, Type.PAWN);
+        verifyRepresentation('p', whitePawn);
+
+        Piece blackPawn = createPiece(Color.BLACK, Type.PAWN);
+        verifyRepresentation('P', blackPawn);
+    }
+
+    private void verifyRepresentation(final char representation, final Piece piece) {
+        assertEquals(representation, piece.getRepresentation());
+    }
+
 }


### PR DESCRIPTION
## 구현 내용
- [x]  기물 색 enum 구현
- [x]  기물 종류 enum 구현
- [x]  팩토리 메소드 구현
- [x]  체스판을 Piece로 초기화
- [x]  보드 자료구조 개선 (ArrayList<Rank>)
- [x]  기물 색과 종류에 해당하는 기물 개수 반환
- [x]  주어진 위치의 기물 조회
    - [x]  위치 값을 처리하는 클래스
- [x]  임의의 기물을 체스판 위에 추가
    - [x]  빈 상태의 체스판 초기화
    - [x]  기존 Piece 제거 후 새로운 Piece 추가
- [x]  점수 계산
- [x]  기물 정렬
    - [x]  높은 순서 정렬(내림차순)
    - [x]  낮은 순서 정렬(오름차순)

## 고민 사항
- 팩토리 메소드를 구현하기 위해 Piece 클래스를 어떻게 해야 할지
  - Piece 클래스 내에 객체를 생성하는 메소드가 너무 많아서 복잡했고, 팩토리 메소드를 제대로 구현한 것 같지 않았다. 그래서 Piece 클래스에서 객체를 생성하는 것이 아니라 Piece 클래스를 상속받은 다른 기물 클래스를 구현하여 객체를 생성했다.
- 점수를 계산하는 클래스를 따로 작성 해야 할지
  - 단일 책임 원칙을 지키고자 점수 계산하는 클래스를 따로 작성 해야 할지 고민했다. 하지만 점수를 계산하는 메소드가 Board 클래스의 board 변수를 사용하기 때문에 의존 관계를 형성해서, 그냥 Board 클래스에서 점수 계산을 수행했다.
- 객체 비교를 어떻게 해야 할지
  - assertEquals()를 사용해 새로 생성한 객체와 기존의 객체를 비교하면 참조하는 주소가 다르기 때문에 당연히 오류가 난다. 다른 팀원도 이것 때문에 고민하고 있었는데, 피어 세션을 통해서 equals를 오버라이딩해서 사용하는 방법을 알 수 있었다. 이 방법을 사용하면 참조 주소가 아라 객체가 가진 속성(상태)만을 사용해서 비교할 수 있다.
  - 검색해보니 equals를 오버라이딩해서 사용할 때는 hashCode도 함께 오버라이딩해서 사용해야 해시 기반 컬렉션의 동작이 예상대로 잘 동작한다고 한다. 현재 테스트에 사용하는 비교에서는 해시 기반 컬렉션을 사용하지 않아서 뺄지 고민했다. 추후 해시 기반 컬렉션을 사용할 가능성을 열어두고자 hashCode도 함께 오버라이딩했다.

## 기타
for 문 보다 Stream API를 사용하려고 노력하기
