### PR TITLE
[박선미] step-7 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
 }
 
 test {

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -16,7 +16,7 @@ public class GameController {
 
     private final InputView inputView;
     private final OutputView outputView;
-    private Board chessBoard;
+    private final Board chessBoard;
     private final Scanner sc;
 
 
@@ -47,37 +47,38 @@ public class GameController {
         outputView.gameEnd();
     }
 
-    private String inputCommandUntilPossibleToMove(int round){
-        boolean result = true;
+    private String inputCommandUntilPossibleToMove(int round) {
+        boolean enterCorrectly = true;
         String command = "";
-        while(result){
-            result = false;
+        while (enterCorrectly) {
+            enterCorrectly = false;
             inputView.beforeMove(round);
             command = sc.nextLine();
-            if(exit(command)) {
-                break;
-            }
-
-            try{
+            try {
                 isStartWithMove(command);
-            }catch (IllegalAccessException e) {
+            } catch (IllegalArgumentException e) {
                 outputView.print(e.toString());
-                result = true;
+                enterCorrectly = true;
             }
         }
         return command;
     }
 
-    private void isStartWithMove(String command) throws IllegalAccessException {
+    private void isStartWithMove(String command) throws IllegalArgumentException {
         if (command.startsWith(MOVE_COMMAND)) {
             String[] splitCommand = command.split(SPACE);
-            Validation.isOutOfBoard(splitCommand[1]);
-            Validation.isOutOfBoard(splitCommand[2]);
+            validateCommand(splitCommand[1]);
+            validateCommand(splitCommand[2]);
             commandMove(splitCommand[1], splitCommand[2]);
         }
     }
 
-    private void commandMove(String src, String dst) throws IllegalAccessException {
+    private void validateCommand(String command) throws IllegalArgumentException {
+        Validation.isRegularCommand(command);
+        Validation.isOutOfBoard(command);
+    }
+
+    private void commandMove(String src, String dst) throws IllegalArgumentException {
         Position srcPosition = Position.transfer(src);
         Position dstPosition = Position.transfer(dst);
         chessBoard.move(srcPosition, dstPosition);
@@ -87,4 +88,7 @@ public class GameController {
         return command.startsWith(EXIT_COMMAND);
     }
 
+    public void forTest_validateCommand(String cmd) throws IllegalArgumentException {
+        validateCommand(cmd);
+    }
 }

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -2,6 +2,7 @@ package softeer2nd.chess.controller;
 
 import softeer2nd.chess.domain.Board;
 import softeer2nd.chess.domain.VO.Position;
+import softeer2nd.chess.utils.Validation;
 import softeer2nd.chess.view.InputView;
 import softeer2nd.chess.view.OutputView;
 
@@ -29,6 +30,7 @@ public class GameController {
     public void start() {
         chessBoard.initialize();
         inputView.gameStart();
+        outputView.afterMove(chessBoard.show());
         run();
     }
 
@@ -52,6 +54,10 @@ public class GameController {
             result = false;
             inputView.beforeMove(round);
             command = sc.nextLine();
+            if(exit(command)) {
+                break;
+            }
+
             try{
                 isStartWithMove(command);
             }catch (IllegalAccessException e) {
@@ -65,6 +71,8 @@ public class GameController {
     private void isStartWithMove(String command) throws IllegalAccessException {
         if (command.startsWith(MOVE_COMMAND)) {
             String[] splitCommand = command.split(SPACE);
+            Validation.isOutOfBoard(splitCommand[1]);
+            Validation.isOutOfBoard(splitCommand[2]);
             commandMove(splitCommand[1], splitCommand[2]);
         }
     }

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -83,7 +83,7 @@ public class GameController {
 
     private void moveOnlyYourPieces(String position, int round) { // 0: 흰, 1: 검
         Position targetPosition = Position.transfer(position);
-        if (!chessBoard.checkMovableByColor(targetPosition, round)) {
+        if (!chessBoard.checkTurnByColor(targetPosition, round)) {
             throw new IllegalArgumentException("자신의 기물만 움직일 수 있습니다.");
         }
     }

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -80,7 +80,6 @@ public class GameController {
     private void commandMove(String src, String dst) throws IllegalAccessException {
         Position srcPosition = Position.transfer(src);
         Position dstPosition = Position.transfer(dst);
-        chessBoard.possibleToMove(srcPosition, dstPosition);
         chessBoard.move(srcPosition, dstPosition);
     }
 

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -57,7 +57,7 @@ public class GameController {
             command = sc.nextLine();
             try {
                 isStartWithMove(command, round % Color.COLOR_COUNT);
-            } catch (IllegalArgumentException e) {
+            } catch (Exception e) {
                 outputView.print(e.toString());
                 enterCorrectly = true;
             }

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -65,7 +65,7 @@ public class GameController {
         return command;
     }
 
-    private void isStartWithMove(String command, int round) throws IllegalArgumentException {
+    private void isStartWithMove(String command, int round) throws Exception {
         if (command.startsWith(MOVE_COMMAND)) {
             String[] splitCommand = command.split(SPACE);
             validateCommand(splitCommand[1]);
@@ -76,7 +76,7 @@ public class GameController {
         }
     }
 
-    private void validateCommand(String position) throws IllegalArgumentException {
+    private void validateCommand(String position) throws Exception {
         Validation.isRegularCommand(position);
         Validation.isOutOfBoard(position);
     }
@@ -88,7 +88,7 @@ public class GameController {
         }
     }
 
-    private void commandMove(String src, String dst) throws IllegalArgumentException {
+    private void commandMove(String src, String dst) throws Exception {
         Position srcPosition = Position.transfer(src);
         Position dstPosition = Position.transfer(dst);
         chessBoard.move(srcPosition, dstPosition);
@@ -98,11 +98,4 @@ public class GameController {
         return command.startsWith(EXIT_COMMAND);
     }
 
-    public void forTest_moveOnlyYourPieces(String cmd, int round) throws IllegalArgumentException {
-        moveOnlyYourPieces(cmd, round);
-    }
-
-    public void forTest_validateCommand(String cmd) throws IllegalArgumentException {
-        validateCommand(cmd);
-    }
 }

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -38,11 +38,11 @@ public class GameController {
         int round = 0;
         while (true) {
             String command = inputCommandUntilPossibleToMove(round);
-            round++;
             if (exit(command)) {
                 break;
             }
             outputView.afterMove(chessBoard.show());
+            round++;
         }
         outputView.gameEnd();
     }
@@ -55,7 +55,7 @@ public class GameController {
             inputView.beforeMove(round);
             command = sc.nextLine();
             try {
-                isStartWithMove(command);
+                isStartWithMove(command, round);
             } catch (IllegalArgumentException e) {
                 outputView.print(e.toString());
                 enterCorrectly = true;
@@ -64,10 +64,12 @@ public class GameController {
         return command;
     }
 
-    private void isStartWithMove(String command) throws IllegalArgumentException {
+    private void isStartWithMove(String command, int round) throws IllegalArgumentException {
         if (command.startsWith(MOVE_COMMAND)) {
             String[] splitCommand = command.split(SPACE);
             validateCommand(splitCommand[1]);
+            moveOnlyYourPieces(splitCommand[1], round);
+
             validateCommand(splitCommand[2]);
             commandMove(splitCommand[1], splitCommand[2]);
         }
@@ -76,6 +78,13 @@ public class GameController {
     private void validateCommand(String command) throws IllegalArgumentException {
         Validation.isRegularCommand(command);
         Validation.isOutOfBoard(command);
+    }
+
+    private void moveOnlyYourPieces(String command, int round) { // 0: 흰, 1: 검
+        Position targetPosition = Position.transfer(command);
+        if (!chessBoard.checkMovableByColor(targetPosition, round)) {
+            throw new IllegalArgumentException("자신의 기물만 움직일 수 있습니다.");
+        }
     }
 
     private void commandMove(String src, String dst) throws IllegalArgumentException {

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -3,6 +3,7 @@ package softeer2nd.chess.controller;
 import softeer2nd.chess.domain.Board;
 import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.State;
 import softeer2nd.chess.utils.Validation;
 import softeer2nd.chess.view.InputView;
 import softeer2nd.chess.view.OutputView;
@@ -19,6 +20,7 @@ public class GameController {
     private final OutputView outputView;
     private final Board chessBoard;
     private final Scanner sc;
+    private State gameState;
 
 
     public GameController(Board newBoard) {
@@ -26,6 +28,7 @@ public class GameController {
         this.inputView = new InputView();
         this.outputView = new OutputView();
         this.sc = new Scanner(System.in);
+        gameState = State.START;
     }
 
     public void start() {
@@ -37,15 +40,14 @@ public class GameController {
 
     void run() {
         int round = 0;
-        while (true) {
-            String command = inputCommandUntilPossibleToMove(round);
+        while (!gameState.isEnd()) {
+            String command = inputCommandUntilPossibleToMove(round++);
             if (exit(command)) {
                 break;
             }
             outputView.afterMove(chessBoard.show());
-            round++;
         }
-        outputView.gameEnd();
+        outputView.gameEnd(round);
     }
 
     private String inputCommandUntilPossibleToMove(int round) {
@@ -91,7 +93,10 @@ public class GameController {
     private void commandMove(String src, String dst) throws Exception {
         Position srcPosition = Position.transfer(src);
         Position dstPosition = Position.transfer(dst);
-        chessBoard.move(srcPosition, dstPosition);
+        boolean kingDied = chessBoard.move(srcPosition, dstPosition);
+        if(kingDied){
+            this.gameState = State.END;
+        }
     }
 
     private boolean exit(String command) {

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -13,6 +13,8 @@ import java.util.Scanner;
 import static softeer2nd.chess.utils.StringUtils.SPACE;
 
 public class GameController {
+    public static final int FROM_POSITION_INDEX = 1;
+    public static final int TO_POSITION_INDEX = 2;
     private final String MOVE_COMMAND = "move";
     private final String EXIT_COMMAND = "exit";
 
@@ -60,7 +62,7 @@ public class GameController {
             try {
                 isStartWithMove(command, round % Color.COLOR_COUNT);
             } catch (Exception e) {
-                outputView.print(e.toString());
+                outputView.print(e.getMessage());
                 enterCorrectly = true;
             }
         }
@@ -70,11 +72,14 @@ public class GameController {
     private void isStartWithMove(String command, int round) throws Exception {
         if (command.startsWith(MOVE_COMMAND)) {
             String[] splitCommand = command.split(SPACE);
-            validateCommand(splitCommand[1]);
-            moveOnlyYourPieces(splitCommand[1], round);
+            String fromPosition = splitCommand[FROM_POSITION_INDEX];
+            String toPosition = splitCommand[TO_POSITION_INDEX];
 
-            validateCommand(splitCommand[2]);
-            commandMove(splitCommand[1], splitCommand[2]);
+            validateCommand(fromPosition);
+            moveOnlyYourPieces(fromPosition, round);
+
+            validateCommand(toPosition);
+            commandMove(fromPosition, toPosition);
         }
     }
 

--- a/src/main/java/softeer2nd/chess/controller/GameController.java
+++ b/src/main/java/softeer2nd/chess/controller/GameController.java
@@ -2,6 +2,7 @@ package softeer2nd.chess.controller;
 
 import softeer2nd.chess.domain.Board;
 import softeer2nd.chess.domain.VO.Position;
+import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.utils.Validation;
 import softeer2nd.chess.view.InputView;
 import softeer2nd.chess.view.OutputView;
@@ -55,7 +56,7 @@ public class GameController {
             inputView.beforeMove(round);
             command = sc.nextLine();
             try {
-                isStartWithMove(command, round);
+                isStartWithMove(command, round % Color.COLOR_COUNT);
             } catch (IllegalArgumentException e) {
                 outputView.print(e.toString());
                 enterCorrectly = true;
@@ -75,13 +76,13 @@ public class GameController {
         }
     }
 
-    private void validateCommand(String command) throws IllegalArgumentException {
-        Validation.isRegularCommand(command);
-        Validation.isOutOfBoard(command);
+    private void validateCommand(String position) throws IllegalArgumentException {
+        Validation.isRegularCommand(position);
+        Validation.isOutOfBoard(position);
     }
 
-    private void moveOnlyYourPieces(String command, int round) { // 0: 흰, 1: 검
-        Position targetPosition = Position.transfer(command);
+    private void moveOnlyYourPieces(String position, int round) { // 0: 흰, 1: 검
+        Position targetPosition = Position.transfer(position);
         if (!chessBoard.checkMovableByColor(targetPosition, round)) {
             throw new IllegalArgumentException("자신의 기물만 움직일 수 있습니다.");
         }
@@ -95,6 +96,10 @@ public class GameController {
 
     private boolean exit(String command) {
         return command.startsWith(EXIT_COMMAND);
+    }
+
+    public void forTest_moveOnlyYourPieces(String cmd, int round) throws IllegalArgumentException {
+        moveOnlyYourPieces(cmd, round);
     }
 
     public void forTest_validateCommand(String cmd) throws IllegalArgumentException {

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -13,6 +13,7 @@ import java.util.stream.IntStream;
 import static softeer2nd.chess.utils.StringUtils.NEWLINE;
 import static softeer2nd.chess.utils.StringUtils.SPACE;
 import static softeer2nd.chess.utils.Validation.*;
+import static softeer2nd.chess.utils.Validation.THROW_ALREADY_PIECE_EXIST;
 
 public class Board {
 
@@ -47,8 +48,6 @@ public class Board {
 
 
     private void checkMovePossibility(Position src, Position dst) throws IllegalArgumentException {
-        Piece target = ranks.get(src.getRow()).find(src.getCol());
-        // Direction, count로 변환
         Direction direction = src.getDirection(dst);
         if (direction.isNone()) {
             NOT_A_MOVE_COMMAND();
@@ -56,12 +55,26 @@ public class Board {
 
         int count = getCount(src, dst);
 
-        if (!target.verifyMovePosition(direction, count)) {
+        Piece from = getTargetAt(src);
+        if (!from.verifyMovePosition(direction, count)) {
             NOT_ALLOW_DIRECTION();
         }
         if (!notExistPiece(src.getRow(), src.getCol(), direction, count)) {
             THROW_ALREADY_PIECE_EXIST();
         }
+
+        Piece to = getTargetAt(dst);
+        if(isSameColor(from, to)){
+            THROW_ALREADY_PIECE_EXIST();
+        }
+    }
+
+    private static boolean isSameColor(Piece from, Piece to) {
+        return from.isWhite() && to.isWhite() || from.isBlack() && to.isBlack();
+    }
+
+    private Piece getTargetAt(Position position) {
+        return ranks.get(position.getRow()).find(position.getCol());
     }
 
     private static int getCount(Position src, Position dst) {

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -48,10 +48,11 @@ public class Board {
         );
     }
 
-    public void move(Position srcPosition, Position dstPosition) throws Exception {
-        checkMovePossibility(srcPosition, dstPosition);
+    public boolean move(Position srcPosition, Position dstPosition) throws Exception {
+        Piece piece = checkMovePossibility(srcPosition, dstPosition);
         Piece beforeChange = deleteOriginPiece(srcPosition);
         addPieceAt(dstPosition, beforeChange);
+        return piece.getType() == Type.KING;
     }
 
     private Piece deleteOriginPiece(Position position) {
@@ -70,7 +71,7 @@ public class Board {
         ranks.get(dstRank).add(position, piece);
     }
 
-    private void checkMovePossibility(Position srcPosition, Position dstPosition) throws Exception {
+    private Piece checkMovePossibility(Position srcPosition, Position dstPosition) throws Exception {
         Direction headDirection = srcPosition.getDirection(dstPosition);
         if (headDirection.isNone()) {
             throw new NotMoveCommandException();
@@ -86,6 +87,8 @@ public class Board {
             checkSameColor(from, to);
             checkPawnAttack(from, headDirection);
         }
+
+        return to;
     }
 
     private void checkPawnAttack(Piece from, Direction direction) throws PawnAttackException {

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -6,6 +6,9 @@ import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
 import softeer2nd.chess.domain.pieces.Pawn;
 import softeer2nd.chess.domain.pieces.Piece;
+import softeer2nd.chess.exception.AlreadyPieceExistException;
+import softeer2nd.chess.exception.NotAllowDirectionException;
+import softeer2nd.chess.exception.NotMoveCommandException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +48,7 @@ public class Board {
         );
     }
 
-    public void move(Position srcPosition, Position dstPosition) throws IllegalArgumentException {
+    public void move(Position srcPosition, Position dstPosition) throws Exception {
         checkMovePossibility(srcPosition, dstPosition);
         Piece beforeChange = deleteOriginPiece(srcPosition);
         addPieceAt(dstPosition, beforeChange);
@@ -67,10 +70,10 @@ public class Board {
         ranks.get(dstRank).add(position, piece);
     }
 
-    private void checkMovePossibility(Position srcPosition, Position dstPosition) throws IllegalArgumentException {
+    private void checkMovePossibility(Position srcPosition, Position dstPosition) throws Exception {
         Direction headDirection = srcPosition.getDirection(dstPosition);
         if (headDirection.isNone()) {
-            NOT_A_MOVE_COMMAND();
+            throw new NotAllowDirectionException();
         }
 
         int hopeCount = srcPosition.getHopeCount(dstPosition);
@@ -87,18 +90,18 @@ public class Board {
         return target.find(position.getColumn());
     }
 
-    private void checkIsMovable(Position src, Direction direction, int hopeCount, Piece from) {
+    private void checkIsMovable(Position src, Direction direction, int hopeCount, Piece from) throws Exception {
         if (!from.verifyMovePosition(direction, hopeCount)) {
-            NOT_ALLOW_DIRECTION();
+            throw new NotMoveCommandException();
         }
         if (existPieceInDirection(src, direction, hopeCount)) {
-            THROW_ALREADY_PIECE_EXIST();
+            throw new AlreadyPieceExistException();
         }
     }
 
-    private void checkSameColor(Piece piece1, Piece piece2) {
+    private void checkSameColor(Piece piece1, Piece piece2) throws Exception {
         if (isSameTeam(piece1, piece2)) {
-            THROW_ALREADY_PIECE_EXIST();
+            throw new AlreadyPieceExistException();
         }
     }
 

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -12,6 +12,7 @@ import java.util.stream.IntStream;
 
 import static softeer2nd.chess.utils.StringUtils.NEWLINE;
 import static softeer2nd.chess.utils.StringUtils.SPACE;
+import static softeer2nd.chess.utils.Validation.*;
 
 public class Board {
 
@@ -45,19 +46,21 @@ public class Board {
     }
 
 
-    public boolean possibleToMove(Position src, Position dst) throws IllegalAccessException {
+    public void possibleToMove(Position src, Position dst) throws IllegalAccessException {
         Piece target = ranks.get(src.getRow()).find(src.getCol());
         // Direction, count로 변환
         Direction direction = src.getDirection(dst);
         if (direction.isNone()) {
-            throw new IllegalAccessException("올바른 이동이 아닙니다.");
+            NOT_A_MOVE_COMMAND();
         }
         if (target.getType() == Type.KNIGHT && isKnightMoving(direction)) {
-            return true;
+            return;
         }
 
-        int x = src.getRow(); int y = src.getCol();
-        int nx = dst.getRow(); int ny = dst.getCol();
+        int x = src.getRow();
+        int y = src.getCol();
+        int nx = dst.getRow();
+        int ny = dst.getCol();
         int count = Math.abs(nx - x);
         if (nx - x == 0) {
             count = Math.abs(ny - y);
@@ -65,11 +68,12 @@ public class Board {
 
         // 타겟이 이동할 수 잇ㄴ느 방향인지?
         // 가는 길에 다른 기물이 없는지?
-        if(target.verifyMovePosition(direction, count)
-                && nextStep(src.getRow(), src.getCol(), direction, count)) {
-            return true;
+        if (!target.verifyMovePosition(direction, count)){
+            NOT_ALLOW_DIRECTION();
         }
-        throw new IllegalAccessException("이동할 수 없는 입력입니다.");
+        if(!nextStep(src.getRow(), src.getCol(), direction, count)) {
+            THROW_ALREADY_PIECE_EXIST();
+        }
     }
 
     private boolean isKnightMoving(Direction direction) {
@@ -77,14 +81,15 @@ public class Board {
     }
 
     private boolean nextStep(int row, int col, Direction direction, int count) {
-        if(count ==0 ) return true;
+        if (count == 0) return true;
         boolean result = true;
 
-        if(ranks.get(row).isEmptyPlace(col)){
-            int nextRow = row+direction.getXDegree();
-            int nextCol = col+direction.getYDegree();
-            result &= nextStep(nextRow, nextCol, direction, count-1);
+        int nextRow = row - direction.getXDegree();
+        int nextCol = col - direction.getYDegree();
+        if (!ranks.get(nextRow).isEmptyPlace(nextCol)) {
+            return false;
         }
+        result &= nextStep(nextRow, nextCol, direction, count - 1);
         return result;
     }
 

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -186,4 +186,12 @@ public class Board {
         }
         System.out.println(pointOfTypes);
     }
+
+    public boolean checkMovableByColor(Position position, int round) {
+        Piece target = findPiece(position);
+        if(target.isMovable(round)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -47,24 +47,32 @@ public class Board {
     }
 
 
-    private void checkMovePossibility(Position src, Position dst) throws IllegalArgumentException {
-        Direction direction = src.getDirection(dst);
-        if (direction.isNone()) {
+    private void checkMovePossibility(Position srcPosition, Position dstPosition) throws IllegalArgumentException {
+        Direction headDirection = srcPosition.getDirection(dstPosition);
+        if (headDirection.isNone()) {
             NOT_A_MOVE_COMMAND();
         }
 
-        int count = getCount(src, dst);
+        int count = getCount(srcPosition, dstPosition);
 
-        Piece from = getTargetAt(src);
+        Piece from = getTargetAt(srcPosition);
+        checkMovable(srcPosition, headDirection, count, from);
+
+        Piece to = getTargetAt(dstPosition);
+        checkSameColor(from, to);
+    }
+
+    private void checkMovable(Position src, Direction direction, int count, Piece from) {
         if (!from.verifyMovePosition(direction, count)) {
             NOT_ALLOW_DIRECTION();
         }
         if (!notExistPiece(src.getRow(), src.getCol(), direction, count)) {
             THROW_ALREADY_PIECE_EXIST();
         }
+    }
 
-        Piece to = getTargetAt(dst);
-        if(isSameColor(from, to)){
+    private void checkSameColor(Piece piece1, Piece piece2) {
+        if (isSameColor(piece1, piece2)) {
             THROW_ALREADY_PIECE_EXIST();
         }
     }
@@ -186,25 +194,8 @@ public class Board {
         return ranks.get(row).find(col).equalsTypeAndColor(Type.PAWN, color);
     }
 
-    public void sortScore(Color color) {
-        SortedMap<Type, Double> pointOfTypes = new TreeMap<>();
-
-        for (int row = 0; row < MAX_SIZE; row++) {
-            for (int col = 0; col < MAX_SIZE; col++) {
-                Piece target = ranks.get(row).find(col);
-                pointOfTypes.put(target.getType(),
-                        pointOfTypes.getOrDefault(target.getType(), 0D)
-                                + target.getType().getPoint());
-            }
-        }
-        System.out.println(pointOfTypes);
-    }
-
     public boolean checkMovableByColor(Position position, int round) {
         Piece target = findPiece(position);
-        if(target.isMovable(round)) {
-            return true;
-        }
-        return false;
+        return target.isMovable(round);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -53,9 +53,6 @@ public class Board {
         if (direction.isNone()) {
             NOT_A_MOVE_COMMAND();
         }
-        if (target.getType() == Type.KNIGHT && isKnightMoving(direction)) {
-            return;
-        }
 
         int x = src.getRow();
         int y = src.getCol();
@@ -81,6 +78,7 @@ public class Board {
     }
 
     private boolean nextStep(int row, int col, Direction direction, int count) {
+        if(direction.isKnightMove()) return true;
         if (count == 0) return true;
         boolean result = true;
 
@@ -117,7 +115,6 @@ public class Board {
 
         return sb.toString();
     }
-
 
     public void move(Position srcPosition, Position dstPosition) {
         Rank target = ranks.get(srcPosition.getRow());

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -46,7 +46,7 @@ public class Board {
     }
 
 
-    public void possibleToMove(Position src, Position dst) throws IllegalAccessException {
+    private void checkMovePossibility(Position src, Position dst) throws IllegalArgumentException {
         Piece target = ranks.get(src.getRow()).find(src.getCol());
         // Direction, count로 변환
         Direction direction = src.getDirection(dst);
@@ -56,12 +56,10 @@ public class Board {
 
         int count = getCount(src, dst);
 
-        // 타겟이 이동할 수 잇ㄴ느 방향인지?
-        // 가는 길에 다른 기물이 없는지?
         if (!target.verifyMovePosition(direction, count)) {
             NOT_ALLOW_DIRECTION();
         }
-        if (!nextStep(src.getRow(), src.getCol(), direction, count)) {
+        if (!notExistPiece(src.getRow(), src.getCol(), direction, count)) {
             THROW_ALREADY_PIECE_EXIST();
         }
     }
@@ -78,8 +76,8 @@ public class Board {
         return count;
     }
 
-    private boolean nextStep(int row, int col, Direction direction, int count) {
-        if(direction.isKnightMove()) return true;
+    private boolean notExistPiece(int row, int col, Direction direction, int count) {
+        if (direction.isKnightMove()) return true;
         if (count == 0) return true;
         boolean result = true;
 
@@ -88,7 +86,7 @@ public class Board {
         if (!ranks.get(nextRow).isEmptyPlace(nextCol)) {
             return false;
         }
-        result &= nextStep(nextRow, nextCol, direction, count - 1);
+        result &= notExistPiece(nextRow, nextCol, direction, count - 1);
         return result;
     }
 
@@ -117,7 +115,8 @@ public class Board {
         return sb.toString();
     }
 
-    public void move(Position srcPosition, Position dstPosition) {
+    public void move(Position srcPosition, Position dstPosition) throws IllegalArgumentException {
+        checkMovePossibility(srcPosition, dstPosition);
         Rank target = ranks.get(srcPosition.getRow());
         // 제거
         Piece beforeChange = target.delete(srcPosition);

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -54,14 +54,7 @@ public class Board {
             NOT_A_MOVE_COMMAND();
         }
 
-        int x = src.getRow();
-        int y = src.getCol();
-        int nx = dst.getRow();
-        int ny = dst.getCol();
-        int count = Math.abs(nx - x);
-        if (nx - x == 0) {
-            count = Math.abs(ny - y);
-        }
+        int count = getCount(src, dst);
 
         // 타겟이 이동할 수 잇ㄴ느 방향인지?
         // 가는 길에 다른 기물이 없는지?
@@ -73,8 +66,16 @@ public class Board {
         }
     }
 
-    private boolean isKnightMoving(Direction direction) {
-        return Direction.knightDirection().contains(direction);
+    private static int getCount(Position src, Position dst) {
+        int x = src.getRow();
+        int y = src.getCol();
+        int nx = dst.getRow();
+        int ny = dst.getCol();
+        int count = Math.abs(nx - x);
+        if (nx - x == 0) {
+            count = Math.abs(ny - y);
+        }
+        return count;
     }
 
     private boolean nextStep(int row, int col, Direction direction, int count) {
@@ -96,14 +97,14 @@ public class Board {
         StringBuilder sb = new StringBuilder();
 
         sb.append(IntStream.range(0, MAX_SIZE)
-                        .mapToObj(this::view)
+                        .mapToObj(this::joinRankOf)
                         .collect(Collectors.joining()))
                 .append(NEWLINE)
                 .append(COLUMN_REPRESENTATION);
         return sb.toString();
     }
 
-    private String view(int row) {
+    private String joinRankOf(int row) {
         int offsetRow = MAX_SIZE - row;
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/softeer2nd/chess/domain/Board.java
+++ b/src/main/java/softeer2nd/chess/domain/Board.java
@@ -1,9 +1,9 @@
 package softeer2nd.chess.domain;
 
+import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
-import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.pieces.Piece;
 
 import java.util.*;
@@ -68,10 +68,10 @@ public class Board {
 
         // 타겟이 이동할 수 잇ㄴ느 방향인지?
         // 가는 길에 다른 기물이 없는지?
-        if (!target.verifyMovePosition(direction, count)){
+        if (!target.verifyMovePosition(direction, count)) {
             NOT_ALLOW_DIRECTION();
         }
-        if(!nextStep(src.getRow(), src.getCol(), direction, count)) {
+        if (!nextStep(src.getRow(), src.getCol(), direction, count)) {
             THROW_ALREADY_PIECE_EXIST();
         }
     }
@@ -133,8 +133,7 @@ public class Board {
         return ranks.get(row).show();
     }
 
-    public Piece findPiece(String expression) {
-        Position position = Position.transfer(expression);
+    public Piece findPiece(Position position) {
         Rank target = ranks.get(position.getRow());
         return target.find(position.getCol());
     }
@@ -166,7 +165,7 @@ public class Board {
         for (int row = 0; row < MAX_SIZE; row++) {
             for (int col = 0; col < MAX_SIZE; col++) {
                 if (existColoredPawnAt(row, col, color)) {
-                    rowCountOfPawns.set(row, rowCountOfPawns.get(row) + 1);
+                    rowCountOfPawns.set(col, rowCountOfPawns.get(col) + 1);
                 }
             }
         }

--- a/src/main/java/softeer2nd/chess/domain/Rank.java
+++ b/src/main/java/softeer2nd/chess/domain/Rank.java
@@ -11,9 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static softeer2nd.chess.domain.Board.BLACK_PIECE_LINE;
-import static softeer2nd.chess.domain.Board.WHITE_PIECE_LINE;
-
 public class Rank {
     private final List<Piece> pieces;
 
@@ -26,10 +23,6 @@ public class Rank {
     }
 
     public static Rank createPawnArray(Color color) {
-        int row = WHITE_PIECE_LINE + 1;
-        if (color.isBlack()) {
-            row = BLACK_PIECE_LINE - 1;
-        }
         return new Rank(createSamePiecesArray(Type.PAWN, color));
     }
 
@@ -38,11 +31,6 @@ public class Rank {
     }
 
     public static Rank createDifferentPieceArray(Color color) {
-        int row = WHITE_PIECE_LINE;
-        if (color.isBlack()) {
-            row = BLACK_PIECE_LINE;
-        }
-
         List<Piece> result = Arrays.asList( //gg
                 PieceFactory.createRook(color),
                 PieceFactory.createKnight(color),
@@ -67,7 +55,7 @@ public class Rank {
     }
 
     private static Piece pieceOf(Type type, Color color) {
-        if(type == Type.PAWN) {
+        if (type == Type.PAWN) {
             return PieceFactory.createPawn(color);
         }
         return PieceFactory.createBlankPiece();

--- a/src/main/java/softeer2nd/chess/domain/Rank.java
+++ b/src/main/java/softeer2nd/chess/domain/Rank.java
@@ -15,7 +15,7 @@ import static softeer2nd.chess.domain.Board.BLACK_PIECE_LINE;
 import static softeer2nd.chess.domain.Board.WHITE_PIECE_LINE;
 
 public class Rank {
-    private List<Piece> pieces;
+    private final List<Piece> pieces;
 
     private Rank(List<Piece> pieces) {
         this.pieces = pieces;
@@ -86,15 +86,12 @@ public class Rank {
                 .count();
     }
 
-    public boolean isEmptyPlace(int col) {
-        return pieces.get(col).getType() == Type.BLANK;
-    }
     public Piece find(int col) {
         return pieces.get(col);
     }
 
     public void add(Position position, Piece piece) {
-        int col = position.getCol();
+        int col = position.getColumn();
         this.pieces.set(col, piece);
     }
 
@@ -106,11 +103,8 @@ public class Rank {
                 .sum();
     }
 
-    public Piece delete(Position position) {
-        int col = position.getCol();
-        Piece beforeChange = find(col);
-        // position 같은 객체..?
+    public void delete(Position position) {
+        int col = position.getColumn();
         this.pieces.set(col, PieceFactory.createBlankPiece());
-        return beforeChange;
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/VO/Position.java
+++ b/src/main/java/softeer2nd/chess/domain/VO/Position.java
@@ -5,11 +5,11 @@ import softeer2nd.chess.domain.enums.Direction;
 
 public class Position {
     private int row;
-    private int col;
+    private int column;
 
-    public Position(int row, int col) {
+    public Position(int row, int column) {
         this.row = row;
-        this.col = col;
+        this.column = column;
     }
 
     public static Position transfer(String expression) {
@@ -20,15 +20,22 @@ public class Position {
 
     public Direction getDirection(Position nextPosition) {
         int dRow = this.row - nextPosition.getRow();
-        int dCol = this.col - nextPosition.getCol();
+        int dCol = this.column - nextPosition.getColumn();
         return Direction.getDirection(dRow, dCol);
+    }
+
+    // 두 끝 점이 일직선에 위치할 때 사용한다.
+    public int getHopeCount(Position position) {
+        int nRow = position.getRow();
+        int nColumn = position.getColumn();
+        return (nRow - this.column == 0)? Math.abs(nRow - this.row) : Math.abs(nColumn - this.column);
     }
 
     public int getRow() {
         return row;
     }
 
-    public int getCol(){
-        return col;
+    public int getColumn(){
+        return column;
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/enums/Color.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Color.java
@@ -6,6 +6,7 @@ public enum Color {
     NONE(-1),
     ;
     private final int round;
+    public static final int COLOR_COUNT = 2;
 
     Color(int round) {
         this.round = round;

--- a/src/main/java/softeer2nd/chess/domain/enums/Color.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Color.java
@@ -1,10 +1,15 @@
 package softeer2nd.chess.domain.enums;
 
 public enum Color {
-    WHITE,
-    BLACK,
-    NONE,
+    WHITE(0),
+    BLACK(1),
+    NONE(-1),
     ;
+    private final int round;
+
+    Color(int round) {
+        this.round = round;
+    }
 
     public boolean isWhite() {
         return this == WHITE;
@@ -12,5 +17,9 @@ public enum Color {
 
     public boolean isBlack() {
         return this == BLACK;
+    }
+
+    public boolean checkRound(int round) {
+        return this.round == round;
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/enums/Direction.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Direction.java
@@ -7,7 +7,7 @@ public enum Direction {
     NORTHEAST(1, 1),
     EAST(0, 1),
     SOUTHEAST(-1, 1),
-    SOUTH(-1,  0),
+    SOUTH(-1, 0),
     SOUTHWEST(-1, -1),
     WEST(0, -1),
     NORTHWEST(1, -1),
@@ -47,8 +47,14 @@ public enum Direction {
     }
 
     private boolean isSame(int x, int y) {
-        if (x == 0) y /= Math.abs(y);
-        else if (y == 0) x /= Math.abs(x);
+        int absX = Math.abs(x);
+        int absY = Math.abs(y);
+        if (x == 0) y /= absY;
+        else if (y == 0) x /= absX;
+        if (absX == absY) {
+            x /= absX;
+            y /= absY;
+        }
         return xDegree == x && yDegree == y;
     }
 

--- a/src/main/java/softeer2nd/chess/domain/enums/Direction.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Direction.java
@@ -99,4 +99,8 @@ public enum Direction {
     private int getNextColumn(int column) {
         return column - this.yDegree;
     }
+
+    public boolean isStraight() {
+        return this == NORTH || this == SOUTH;
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/enums/Direction.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Direction.java
@@ -1,5 +1,7 @@
 package softeer2nd.chess.domain.enums;
 
+import softeer2nd.chess.domain.VO.Position;
+
 import java.util.Set;
 
 public enum Direction {
@@ -31,14 +33,6 @@ public enum Direction {
         this.yDegree = yDegree;
     }
 
-    public int getXDegree() {
-        return xDegree;
-    }
-
-    public int getYDegree() {
-        return yDegree;
-    }
-
     public static Direction getDirection(int dRow, int dCol) {
         for (Direction direction : Direction.values()) {
             if (direction.isSame(dRow, dCol)) return direction;
@@ -49,8 +43,10 @@ public enum Direction {
     private boolean isSame(int x, int y) {
         int absX = Math.abs(x);
         int absY = Math.abs(y);
+
         if (x == 0) y /= absY;
         else if (y == 0) x /= absX;
+
         if (absX == absY) {
             x /= absX;
             y /= absY;
@@ -88,5 +84,19 @@ public enum Direction {
 
     public boolean isKnightMove() {
         return knightDirection().contains(this);
+    }
+
+    public Position getNextPosition(Position position) {
+        int row = position.getRow();
+        int col = position.getColumn();
+        return new Position(getNextRow(row), getNextColumn(col));
+    }
+
+    private int getNextRow(int row) {
+        return row - this.xDegree;
+    }
+
+    private int getNextColumn(int column) {
+        return column - this.yDegree;
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/enums/Direction.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/Direction.java
@@ -85,4 +85,8 @@ public enum Direction {
     public static Set<Direction> blackPawnDirection() {
         return Set.of(SOUTH, SOUTHEAST, SOUTHWEST);
     }
+
+    public boolean isKnightMove() {
+        return knightDirection().contains(this);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/enums/State.java
+++ b/src/main/java/softeer2nd/chess/domain/enums/State.java
@@ -1,0 +1,12 @@
+package softeer2nd.chess.domain.enums;
+
+public enum State {
+    START,
+    DOING,
+    END
+    ;
+
+    public boolean isEnd() {
+        return this == END;
+    }
+}

--- a/src/main/java/softeer2nd/chess/domain/pieces/Bishop.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Bishop.java
@@ -1,6 +1,5 @@
 package softeer2nd.chess.domain.pieces;
 
-import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
@@ -51,5 +50,10 @@ public class Bishop implements Piece {
     @Override
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.BISHOP == type && this.color == color;
+    }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Bishop.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Bishop.java
@@ -48,12 +48,12 @@ public class Bishop implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.BISHOP == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.BISHOP == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/BlankPiece.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/BlankPiece.java
@@ -45,12 +45,12 @@ public class BlankPiece implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.BLANK == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.BLANK == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/BlankPiece.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/BlankPiece.java
@@ -48,4 +48,9 @@ public class BlankPiece implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.BLANK == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/King.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/King.java
@@ -49,12 +49,12 @@ public class King implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.KING == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.KING == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/King.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/King.java
@@ -52,4 +52,9 @@ public class King implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.KING == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
@@ -48,12 +48,12 @@ public class Knight implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.KNIGHT == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.KNIGHT == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
@@ -1,6 +1,5 @@
 package softeer2nd.chess.domain.pieces;
 
-import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
@@ -16,7 +15,7 @@ public class Knight implements Piece {
 
     @Override
     public boolean verifyMovePosition(Direction direction, int count) {
-        return false;
+        return Direction.knightDirection().contains(direction);
     }
 
     @Override

--- a/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Knight.java
@@ -51,4 +51,9 @@ public class Knight implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.KNIGHT == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
@@ -7,10 +7,12 @@ import softeer2nd.chess.domain.enums.Type;
 public class Pawn implements Piece {
     private final Color color;
     private final Type type;
+    private boolean moved;
 
     Pawn(Color color) {
         this.color = color;
         this.type = Type.PAWN;
+        this.moved = false;
     }
 
     public boolean verifyAttack(Direction direction, int count) {
@@ -24,13 +26,21 @@ public class Pawn implements Piece {
                 && count == 1;
     }
 
+    public void move(){
+        moved = true;
+    }
 
     @Override
-    public boolean verifyMovePosition(Direction direction, int count) {
-        if (color.isBlack()) {
-            return Direction.SOUTH == direction && count == 1;
+    public boolean verifyMovePosition(Direction direction, int hopeCount) {
+        int howManyCanHope = 2;
+        if (this.moved) {
+            howManyCanHope = 1;
         }
-        return Direction.NORTH == direction && count == 1;
+
+        if (color.isBlack()) {
+            return Direction.SOUTH == direction && hopeCount == howManyCanHope;
+        }
+        return Direction.NORTH == direction && hopeCount == howManyCanHope;
     }
 
     @Override
@@ -63,12 +73,12 @@ public class Pawn implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.PAWN == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.PAWN == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
@@ -13,11 +13,17 @@ public class Pawn implements Piece {
         this.type = Type.PAWN;
     }
 
-//    public boolean attackMove(Direction direction, int count) {
-//        if(color.isBlack()){
-//
-//        }
-//    }
+    public boolean verifyAttack(Direction direction, int count) {
+        if (color.isBlack()) {
+            return (Direction.SOUTHEAST == direction
+                    || Direction.SOUTHWEST == direction)
+                    && count == 1;
+        }
+        return (Direction.NORTHEAST == direction
+                || Direction.NORTHWEST == direction)
+                && count == 1;
+    }
+
 
     @Override
     public boolean verifyMovePosition(Direction direction, int count) {

--- a/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
@@ -60,4 +60,9 @@ public class Pawn implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.PAWN == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Pawn.java
@@ -38,9 +38,9 @@ public class Pawn implements Piece {
         }
 
         if (color.isBlack()) {
-            return Direction.SOUTH == direction && hopeCount == howManyCanHope;
+            return Direction.blackPawnDirection().contains(direction) && hopeCount <= howManyCanHope;
         }
-        return Direction.NORTH == direction && hopeCount == howManyCanHope;
+        return Direction.whitePawnDirection().contains(direction) && hopeCount <= howManyCanHope;
     }
 
     @Override

--- a/src/main/java/softeer2nd/chess/domain/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Piece.java
@@ -21,4 +21,5 @@ public interface Piece {
 
     public boolean equalsTypeAndColor(Type type, Color color);
 
+    boolean isMovable(int round);
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Piece.java
@@ -1,6 +1,5 @@
 package softeer2nd.chess.domain.pieces;
 
-import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
@@ -19,7 +18,7 @@ public interface Piece {
 
     public boolean isBlack();
 
-    public boolean equalsTypeAndColor(Type type, Color color);
+    public boolean equalsTypeAndColor(Type type, Color hopeCount); // -> equals 상속!
 
-    boolean isMovable(int round);
+    boolean isTurn(int gameRound); // 이름 바꾸기
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Queen.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Queen.java
@@ -48,12 +48,12 @@ public class Queen implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.QUEEN == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.QUEEN == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Queen.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Queen.java
@@ -51,4 +51,9 @@ public class Queen implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.QUEEN == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Rook.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Rook.java
@@ -51,4 +51,9 @@ public class Rook implements Piece {
     public boolean equalsTypeAndColor(Type type, Color color) {
         return Type.ROOK == type && this.color == color;
     }
+
+    @Override
+    public boolean isMovable(int round) {
+        return color.checkRound(round);
+    }
 }

--- a/src/main/java/softeer2nd/chess/domain/pieces/Rook.java
+++ b/src/main/java/softeer2nd/chess/domain/pieces/Rook.java
@@ -48,12 +48,12 @@ public class Rook implements Piece {
     }
 
     @Override
-    public boolean equalsTypeAndColor(Type type, Color color) {
-        return Type.ROOK == type && this.color == color;
+    public boolean equalsTypeAndColor(Type type, Color hopeCount) {
+        return Type.ROOK == type && this.color == hopeCount;
     }
 
     @Override
-    public boolean isMovable(int round) {
-        return color.checkRound(round);
+    public boolean isTurn(int gameRound) {
+        return color.checkRound(gameRound);
     }
 }

--- a/src/main/java/softeer2nd/chess/exception/AlreadyPieceExistException.java
+++ b/src/main/java/softeer2nd/chess/exception/AlreadyPieceExistException.java
@@ -1,0 +1,8 @@
+package softeer2nd.chess.exception;
+
+public class AlreadyPieceExistException extends CustomException{
+    private static final String ALREADY_PIECE_EXIST_MESSAGE = "동선에 기물이 존재하여 이동할 수 없습니다.";
+    public AlreadyPieceExistException() {
+        super(ALREADY_PIECE_EXIST_MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/CustomException.java
+++ b/src/main/java/softeer2nd/chess/exception/CustomException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+import softeer2nd.chess.view.OutputView;
+
+public abstract class CustomException extends Exception {
+    public CustomException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/NotAllowDirectionException.java
+++ b/src/main/java/softeer2nd/chess/exception/NotAllowDirectionException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class NotAllowDirectionException extends CustomException {
+    private static final String NOT_ALLOW_DIRECTION_MESSAGE = "이동할 수 없는 방향입니다.";
+
+    public NotAllowDirectionException() {
+        super(NOT_ALLOW_DIRECTION_MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/NotMoveCommandException.java
+++ b/src/main/java/softeer2nd/chess/exception/NotMoveCommandException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class NotMoveCommandException extends CustomException {
+    private static final String NOT_MOVE_COMMAND = "이동을 하지 않는 명령입니다.";
+
+    public NotMoveCommandException() {
+        super(NOT_MOVE_COMMAND);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/NotRegularArgumentException.java
+++ b/src/main/java/softeer2nd/chess/exception/NotRegularArgumentException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class NotRegularArgumentException  extends CustomException{
+    private static final String Not_REGULAR_ARGUMENT_MESSAGE = "이동 명령은 연속된 소문자 하나와 숫자 문자 하나로 표현해주세요.";
+
+    public NotRegularArgumentException() {
+        super(Not_REGULAR_ARGUMENT_MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/OutOfBoardException.java
+++ b/src/main/java/softeer2nd/chess/exception/OutOfBoardException.java
@@ -1,0 +1,8 @@
+package softeer2nd.chess.exception;
+
+public class OutOfBoardException extends CustomException {
+    private static final String OUT_OF_BOARD_MESSAGE = "이동 입력이 범위 밖을 넘어갔습니다.";
+    public OutOfBoardException() {
+        super(OUT_OF_BOARD_MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/PawnAttackException.java
+++ b/src/main/java/softeer2nd/chess/exception/PawnAttackException.java
@@ -1,0 +1,8 @@
+package softeer2nd.chess.exception;
+
+public class PawnAttackException extends CustomException{
+    private static final String PAWN_ATTACK_MESSAGE = "폰 공격은 대각선으로만 가능합니다.";
+    public PawnAttackException() {
+        super(PAWN_ATTACK_MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/utils/Validation.java
+++ b/src/main/java/softeer2nd/chess/utils/Validation.java
@@ -14,7 +14,7 @@ public class Validation {
         Matcher matcher = pattern.matcher(command);
 
         if(!matcher.matches()){
-            throw new IllegalArgumentException("이동 명령은 연속된 소문자 하나와 숫자 문자 하나로 표현해주세요");
+            throw new IllegalArgumentException("이동 명령은 연속된 소문자 하나와 숫자 문자 하나로 표현해주세요.");
         }
     }
 

--- a/src/main/java/softeer2nd/chess/utils/Validation.java
+++ b/src/main/java/softeer2nd/chess/utils/Validation.java
@@ -2,8 +2,21 @@ package softeer2nd.chess.utils;
 
 import softeer2nd.chess.domain.Board;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class Validation {
+    private static final String COMMAND_REGEX = "[a-z][0-9]";
     private Validation() {}
+
+    public static void isRegularCommand(String command) throws IllegalArgumentException {
+        Pattern pattern = Pattern.compile(COMMAND_REGEX);
+        Matcher matcher = pattern.matcher(command);
+
+        if(!matcher.matches()){
+            throw new IllegalArgumentException("이동 명령은 연속된 소문자 하나와 숫자 문자 하나로 표현해주세요");
+        }
+    }
 
     public static void isOutOfBoard(String command) throws IllegalArgumentException {
         int column = command.charAt(0) - 'a';

--- a/src/main/java/softeer2nd/chess/utils/Validation.java
+++ b/src/main/java/softeer2nd/chess/utils/Validation.java
@@ -3,12 +3,13 @@ package softeer2nd.chess.utils;
 import softeer2nd.chess.domain.Board;
 
 public class Validation {
+    private Validation() {}
 
-    public static void isOutOfBoard(String command) throws IllegalAccessException {
+    public static void isOutOfBoard(String command) throws IllegalArgumentException {
         int column = command.charAt(0) - 'a';
         int row = Board.MAX_SIZE - (command.charAt(1) - '0');
         if (notInBound(column) || notInBound(row)) {
-            throw new IllegalAccessException("잘못된 이동 명령을 내렸습니다.");
+            throw new IllegalArgumentException("잘못된 이동 명령을 내렸습니다.");
         }
     }
 
@@ -17,15 +18,15 @@ public class Validation {
     }
 
 
-    public static void NOT_A_MOVE_COMMAND() throws IllegalAccessException {
-        throw new IllegalAccessException("이동을 하지 않는 명령입니다.");
+    public static void NOT_A_MOVE_COMMAND() throws IllegalArgumentException {
+        throw new IllegalArgumentException("이동을 하지 않는 명령입니다.");
     }
 
-    public static void THROW_ALREADY_PIECE_EXIST() throws IllegalAccessException {
-        throw new IllegalAccessException("동선에 기물이 존재하여 이동할 수 없습니다.");
+    public static void THROW_ALREADY_PIECE_EXIST() throws IllegalArgumentException {
+        throw new IllegalArgumentException("동선에 기물이 존재하여 이동할 수 없습니다.");
     }
 
-    public static void NOT_ALLOW_DIRECTION() throws IllegalAccessException {
-        throw new IllegalAccessException("이동할 수 없는 방향입니다.");
+    public static void NOT_ALLOW_DIRECTION() throws IllegalArgumentException {
+        throw new IllegalArgumentException("이동할 수 없는 방향입니다.");
     }
 }

--- a/src/main/java/softeer2nd/chess/utils/Validation.java
+++ b/src/main/java/softeer2nd/chess/utils/Validation.java
@@ -1,0 +1,31 @@
+package softeer2nd.chess.utils;
+
+import softeer2nd.chess.domain.Board;
+
+public class Validation {
+
+    public static void isOutOfBoard(String command) throws IllegalAccessException {
+        int column = command.charAt(0) - 'a';
+        int row = Board.MAX_SIZE - (command.charAt(1) - '0');
+        if (notInBound(column) || notInBound(row)) {
+            throw new IllegalAccessException("잘못된 이동 명령을 내렸습니다.");
+        }
+    }
+
+    private static boolean notInBound(int current) {
+        return 0 > current || current >= Board.MAX_SIZE;
+    }
+
+
+    public static void NOT_A_MOVE_COMMAND() throws IllegalAccessException {
+        throw new IllegalAccessException("이동을 하지 않는 명령입니다.");
+    }
+
+    public static void THROW_ALREADY_PIECE_EXIST() throws IllegalAccessException {
+        throw new IllegalAccessException("동선에 기물이 존재하여 이동할 수 없습니다.");
+    }
+
+    public static void NOT_ALLOW_DIRECTION() throws IllegalAccessException {
+        throw new IllegalAccessException("이동할 수 없는 방향입니다.");
+    }
+}

--- a/src/main/java/softeer2nd/chess/utils/Validation.java
+++ b/src/main/java/softeer2nd/chess/utils/Validation.java
@@ -1,6 +1,7 @@
 package softeer2nd.chess.utils;
 
 import softeer2nd.chess.domain.Board;
+import softeer2nd.chess.exception.*;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,37 +10,24 @@ public class Validation {
     private static final String COMMAND_REGEX = "[a-z][0-9]";
     private Validation() {}
 
-    public static void isRegularCommand(String command) throws IllegalArgumentException {
+    public static void isRegularCommand(String command) throws NotRegularArgumentException {
         Pattern pattern = Pattern.compile(COMMAND_REGEX);
         Matcher matcher = pattern.matcher(command);
 
         if(!matcher.matches()){
-            throw new IllegalArgumentException("이동 명령은 연속된 소문자 하나와 숫자 문자 하나로 표현해주세요.");
+            throw new NotRegularArgumentException();
         }
     }
 
-    public static void isOutOfBoard(String command) throws IllegalArgumentException {
+    public static void isOutOfBoard(String command) throws OutOfBoardException {
         int column = command.charAt(0) - 'a';
         int row = Board.MAX_SIZE - (command.charAt(1) - '0');
         if (notInBound(column) || notInBound(row)) {
-            throw new IllegalArgumentException("잘못된 이동 명령을 내렸습니다.");
+            throw new OutOfBoardException();
         }
     }
 
     private static boolean notInBound(int current) {
         return 0 > current || current >= Board.MAX_SIZE;
-    }
-
-
-    public static void NOT_A_MOVE_COMMAND() throws IllegalArgumentException {
-        throw new IllegalArgumentException("이동을 하지 않는 명령입니다.");
-    }
-
-    public static void THROW_ALREADY_PIECE_EXIST() throws IllegalArgumentException {
-        throw new IllegalArgumentException("동선에 기물이 존재하여 이동할 수 없습니다.");
-    }
-
-    public static void NOT_ALLOW_DIRECTION() throws IllegalArgumentException {
-        throw new IllegalArgumentException("이동할 수 없는 방향입니다.");
     }
 }

--- a/src/main/java/softeer2nd/chess/view/InputView.java
+++ b/src/main/java/softeer2nd/chess/view/InputView.java
@@ -1,5 +1,7 @@
 package softeer2nd.chess.view;
 
+import softeer2nd.chess.domain.enums.Color;
+
 public class InputView {
 
     public void gameStart() {
@@ -8,7 +10,7 @@ public class InputView {
     }
 
     public void beforeMove(int round) {
-        print(round % 2 + 1 + "님 입력 >>> ");
+        print(round % Color.COLOR_COUNT + 1 + "님 입력 >>> ");
     }
 
     private void print(String content){

--- a/src/main/java/softeer2nd/chess/view/OutputView.java
+++ b/src/main/java/softeer2nd/chess/view/OutputView.java
@@ -1,8 +1,17 @@
 package softeer2nd.chess.view;
 
 public class OutputView {
-    public void gameEnd() {
+    public void gameEnd(int round) {
+        printGameResult(round);
         print("게임이 종료됐습니다.");
+    }
+
+    private void printGameResult(int round) {
+        if (round % 2 == 1) {
+            print("백 기물 승리");
+            return;
+        }
+        print("흑 기물 승리");
     }
 
     public void afterMove(String boardResult) {

--- a/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
+++ b/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
@@ -18,21 +18,4 @@ class GameControllerTest {
         Board board = new Board();
         controller = new GameController(board);
     }
-
-    @DisplayName("체스판 범위 내의 입력을 받아야 한다.")
-    @ParameterizedTest
-    @ValueSource(strings = {"a0", "z4", "4d", "aa", "11"})
-    void commandMustInChessBoardSize(String command) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            controller.forTest_validateCommand(command);
-        });
-    }
-
-    @Test
-    @DisplayName("자신의 기물만 움직일 수 있다.")
-    void piecesCanMoveByRound() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            controller.forTest_moveOnlyYourPieces("a2", 1);
-        });
-    }
 }

--- a/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
+++ b/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
@@ -2,6 +2,7 @@ package softeer2nd.chess.controller;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import softeer2nd.chess.domain.Board;
@@ -24,6 +25,14 @@ class GameControllerTest {
     void commandMustInChessBoardSize(String command) {
         assertThrows(IllegalArgumentException.class, () -> {
             controller.forTest_validateCommand(command);
+        });
+    }
+
+    @Test
+    @DisplayName("자신의 기물만 움직일 수 있다.")
+    void piecesCanMoveByRound() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            controller.forTest_moveOnlyYourPieces("a2", 1);
         });
     }
 }

--- a/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
+++ b/src/test/java/softeer2nd/chess/controller/GameControllerTest.java
@@ -1,0 +1,29 @@
+package softeer2nd.chess.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import softeer2nd.chess.domain.Board;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GameControllerTest {
+
+    private GameController controller;
+
+    @BeforeEach
+    void init() {
+        Board board = new Board();
+        controller = new GameController(board);
+    }
+
+    @DisplayName("체스판 범위 내의 입력을 받아야 한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"a0", "z4", "4d", "aa", "11"})
+    void commandMustInChessBoardSize(String command) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            controller.forTest_validateCommand(command);
+        });
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/domain/BoardTest.java
@@ -3,9 +3,9 @@ package softeer2nd.chess.domain;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.domain.pieces.Piece;
 import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.pieces.PieceFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,10 +23,11 @@ public class BoardTest {
     void findPiece() throws Exception {
         board.initialize();
 
-        assertEquals(Piece.createBlackRook(Position.transfer("a8")), board.findPiece("a8"));
-        assertEquals(Piece.createBlackRook(Position.transfer("h8")), board.findPiece("h8"));
-        assertEquals(Piece.createWhiteRook(Position.transfer("a1")), board.findPiece("a1"));
-        assertEquals(Piece.createWhiteRook(Position.transfer("h1")), board.findPiece("h1"));
+        Position expectWhiteRook = Position.transfer("a8");
+        Position expectBlackRook = Position.transfer("a1");
+
+        assertEquals(PieceFactory.createRook(Color.WHITE), board.findPiece(expectWhiteRook));
+        assertEquals(PieceFactory.createRook(Color.BLACK), board.findPiece(expectBlackRook));
     }
 
 
@@ -34,8 +35,9 @@ public class BoardTest {
     @DisplayName("체스판의 기물 점수 구하는가?")
     void calculatePoint() throws Exception {
         board.initialize();
+        double calculated = board.calculatePoint(Color.BLACK);
 
-        assertEquals(38.0, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(38.0, calculated, 0.01);
         assertEquals(38.0, board.calculatePoint(Color.WHITE), 0.01);
 
         System.out.println(board.show());
@@ -49,15 +51,15 @@ public class BoardTest {
         board.initialize();
         String src = "b1";
         String dst = "c3";
-        Position srcPosition = Position.transfer(srcPosition);
-        Position dstPosition = Position.transfer(dstPosition);
+        Position srcPosition = Position.transfer(src);
+        Position dstPosition = Position.transfer(dst);
 
 
         board.move(srcPosition, dstPosition);
 
-        assertEquals(Piece.createBlank(Position.transfer(srcPosition)),
+        assertEquals(PieceFactory.createBlankPiece(),
                 board.findPiece(srcPosition));
-        assertEquals(Piece.createWhiteKnight(Position.transfer(dstPosition)),
+        assertEquals(PieceFactory.createKnight(Color.WHITE),
                 board.findPiece(dstPosition));
     }
 }

--- a/src/test/java/softeer2nd/chess/domain/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/domain/BoardTest.java
@@ -41,7 +41,6 @@ public class BoardTest {
         assertEquals(38.0, board.calculatePoint(Color.WHITE), 0.01);
 
         System.out.println(board.show());
-        board.sortScore(Color.BLACK);
     }
 
 

--- a/src/test/java/softeer2nd/chess/domain/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/domain/BoardTest.java
@@ -81,6 +81,7 @@ public class BoardTest {
 
         assertThrows(IllegalArgumentException.class, () -> {
             board.move(source, destination);
+            System.out.println(board.show());
         });
     }
 }

--- a/src/test/java/softeer2nd/chess/domain/BoardTest.java
+++ b/src/test/java/softeer2nd/chess/domain/BoardTest.java
@@ -7,7 +7,8 @@ import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.pieces.PieceFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BoardTest {
 
@@ -21,20 +22,19 @@ public class BoardTest {
     @Test
     @DisplayName("보드 위에서 기물 찾기")
     void findPiece() throws Exception {
-        board.initialize();
+        Position expectWhiteRook = Position.transfer("a1");
+        Position expectBlackRook = Position.transfer("a8");
 
-        Position expectWhiteRook = Position.transfer("a8");
-        Position expectBlackRook = Position.transfer("a1");
-
-        assertEquals(PieceFactory.createRook(Color.WHITE), board.findPiece(expectWhiteRook));
-        assertEquals(PieceFactory.createRook(Color.BLACK), board.findPiece(expectBlackRook));
+        assertThat(board.findPiece(expectWhiteRook))
+                .isEqualToComparingFieldByFieldRecursively(PieceFactory.createRook(Color.WHITE));
+        assertThat(board.findPiece(expectBlackRook))
+                .isEqualToComparingFieldByFieldRecursively(PieceFactory.createRook(Color.BLACK));
     }
 
 
     @Test
     @DisplayName("체스판의 기물 점수 구하는가?")
     void calculatePoint() throws Exception {
-        board.initialize();
         double calculated = board.calculatePoint(Color.BLACK);
 
         assertEquals(38.0, calculated, 0.01);
@@ -57,9 +57,31 @@ public class BoardTest {
 
         board.move(srcPosition, dstPosition);
 
-        assertEquals(PieceFactory.createBlankPiece(),
-                board.findPiece(srcPosition));
-        assertEquals(PieceFactory.createKnight(Color.WHITE),
-                board.findPiece(dstPosition));
+        assertThat(board.findPiece(srcPosition))
+                .isEqualToComparingFieldByFieldRecursively(PieceFactory.createBlankPiece());
+        assertThat(board.findPiece(dstPosition))
+                .isEqualToComparingFieldByFieldRecursively(PieceFactory.createKnight(Color.WHITE));
+    }
+
+    @Test
+    @DisplayName("나이트는 기물을 뛰어 넘어 이동할 수 있다.")
+    void knightCanMoveOverPiece() {
+        Position source = Position.transfer("b1");
+        Position destination = Position.transfer("c3");
+
+        assertAll(() -> {
+            board.move(source, destination);
+        });
+    }
+
+    @Test
+    @DisplayName("이동 경로에 기물이 있으면 이동할 수 없다.")
+    void canNotMoveIfPieceExist() {
+        Position source = Position.transfer("d1");
+        Position destination = Position.transfer("a4");
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            board.move(source, destination);
+        });
     }
 }

--- a/src/test/java/softeer2nd/chess/domain/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/domain/PieceTest.java
@@ -10,13 +10,12 @@ import softeer2nd.chess.domain.pieces.PieceFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PieceTest {
+class PieceTest {
 
 
     @Test
     @DisplayName("기물과 색깔 별로 인스턴스 생성되는지?")
     void createPiece() {
-
         verifyPiece(PieceFactory.createPawn(Color.WHITE), Type.PAWN, Color.WHITE);
         verifyPiece(PieceFactory.createKing(Color.WHITE), Type.KING, Color.WHITE);
         verifyPiece(PieceFactory.createBishop(Color.WHITE), Type.BISHOP, Color.WHITE);

--- a/src/test/java/softeer2nd/chess/domain/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/domain/PieceTest.java
@@ -2,51 +2,46 @@ package softeer2nd.chess.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.domain.VO.Position;
 import softeer2nd.chess.domain.enums.Color;
 import softeer2nd.chess.domain.enums.Type;
 import softeer2nd.chess.domain.pieces.Piece;
+import softeer2nd.chess.domain.pieces.PieceFactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PieceTest {
 
-    private Position samplePosition = Position.transfer("a1");
 
     @Test
     @DisplayName("기물과 색깔 별로 인스턴스 생성되는지?")
     void createPiece() {
 
-        verifyPiece(Piece.createWhitePawn(samplePosition), Type.PAWN, Color.WHITE);
-        verifyPiece(Piece.createWhiteKing(samplePosition), Type.KING, Color.WHITE);
-        verifyPiece(Piece.createWhiteBishop(samplePosition), Type.BISHOP, Color.WHITE);
-        verifyPiece(Piece.createWhiteKnight(samplePosition), Type.KNIGHT, Color.WHITE);
-        verifyPiece(Piece.createWhiteQueen(samplePosition), Type.QUEEN, Color.WHITE);
-        verifyPiece(Piece.createWhiteRook(samplePosition), Type.ROOK, Color.WHITE);
+        verifyPiece(PieceFactory.createPawn(Color.WHITE), Type.PAWN, Color.WHITE);
+        verifyPiece(PieceFactory.createKing(Color.WHITE), Type.KING, Color.WHITE);
+        verifyPiece(PieceFactory.createBishop(Color.WHITE), Type.BISHOP, Color.WHITE);
+        verifyPiece(PieceFactory.createKnight(Color.WHITE), Type.KNIGHT, Color.WHITE);
+        verifyPiece(PieceFactory.createQueen(Color.WHITE), Type.QUEEN, Color.WHITE);
+        verifyPiece(PieceFactory.createRook(Color.WHITE), Type.ROOK, Color.WHITE);
 
-        verifyPiece(Piece.createBlackPawn(samplePosition), Type.PAWN, Color.BLACK);
-        verifyPiece(Piece.createBlackKing(samplePosition), Type.KING, Color.BLACK);
-        verifyPiece(Piece.createBlackBishop(samplePosition), Type.BISHOP, Color.BLACK);
-        verifyPiece(Piece.createBlackKnight(samplePosition), Type.KNIGHT, Color.BLACK);
-        verifyPiece(Piece.createBlackQueen(samplePosition), Type.QUEEN, Color.BLACK);
-        verifyPiece(Piece.createBlackRook(samplePosition), Type.ROOK, Color.BLACK);
+        verifyPiece(PieceFactory.createPawn(Color.BLACK), Type.PAWN, Color.BLACK);
+        verifyPiece(PieceFactory.createKing(Color.BLACK), Type.KING, Color.BLACK);
+        verifyPiece(PieceFactory.createBishop(Color.BLACK), Type.BISHOP, Color.BLACK);
+        verifyPiece(PieceFactory.createKnight(Color.BLACK), Type.KNIGHT, Color.BLACK);
+        verifyPiece(PieceFactory.createQueen(Color.BLACK), Type.QUEEN, Color.BLACK);
+        verifyPiece(PieceFactory.createRook(Color.BLACK), Type.ROOK, Color.BLACK);
     }
 
     void verifyPiece(Piece piece, Type type, Color color) {
-        assertEquals(color, piece.getColor());
-        assertEquals(type, piece.getType());
+        assertTrue(piece.equalsTypeAndColor(type, color));
     }
 
     @Test
     @DisplayName("Blank 기물이 잘 생성되었는지")
-    void createBlank(){
-        Piece blank = Piece.createBlank(samplePosition);
+    void createBlank() {
+        Piece blank = PieceFactory.createBlankPiece();
 
         assertFalse(blank.isBlack());
         assertFalse(blank.isWhite());
         assertEquals(Type.BLANK, blank.getType());
-        assertEquals(Color.NONE, blank.getColor());
     }
 }

--- a/src/test/java/softeer2nd/chess/domain/PieceTest.java
+++ b/src/test/java/softeer2nd/chess/domain/PieceTest.java
@@ -3,6 +3,7 @@ package softeer2nd.chess.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.Direction;
 import softeer2nd.chess.domain.enums.Type;
 import softeer2nd.chess.domain.pieces.Piece;
 import softeer2nd.chess.domain.pieces.PieceFactory;
@@ -43,5 +44,29 @@ public class PieceTest {
         assertFalse(blank.isBlack());
         assertFalse(blank.isWhite());
         assertEquals(Type.BLANK, blank.getType());
+    }
+
+    @Test
+    @DisplayName("비숍은 대각선으로만 이동할 수 있다.")
+    void bishopMustMoveDiagonally() {
+        Piece bishop = PieceFactory.createBishop(Color.WHITE);
+
+        Direction headingNorth = Direction.NORTH;
+        Direction headingNorthWest = Direction.NORTHWEST;
+
+        assertFalse(bishop.verifyMovePosition(headingNorth, 1));
+        assertTrue(bishop.verifyMovePosition(headingNorthWest, 1));
+    }
+
+    @Test
+    @DisplayName("킹은 모든 방향으로 한 칸 씩 움직여야 한다.")
+    void kingMustMoveOneCount() {
+        Piece king = PieceFactory.createKing(Color.WHITE);
+
+        Direction headingNorth = Direction.NORTH;
+        Direction headingNorthWest = Direction.NORTHWEST;
+
+        assertFalse(king.verifyMovePosition(headingNorth, 3));
+        assertTrue(king.verifyMovePosition(headingNorthWest, 1));
     }
 }

--- a/src/test/java/softeer2nd/chess/domain/pieces/BishopTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/BishopTest.java
@@ -1,0 +1,55 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BishopTest {
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createBishop(Color.WHITE);
+        black = PieceFactory.createBishop(Color.BLACK);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTHEAST", "SOUTHWEST", "SOUTHEAST", "NORTHWEST"})
+    @DisplayName("대각선 방향으로만 이동 가능하다.")
+    void mustMoveBishopDirection(Direction direction) {
+        int hopeCount = 1;
+
+        assertTrue(white.verifyMovePosition(direction, hopeCount));
+        assertTrue(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTH", "NNE", "EAST", "EES"})
+    @DisplayName("나이트 방향으로만 이동 가능하다.")
+    void mustMoveBishopDirection_false(Direction direction) {
+        int hopeCount = 1;
+
+        assertFalse(white.verifyMovePosition(direction, hopeCount));
+        assertFalse(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/BlankPieceTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/BlankPieceTest.java
@@ -1,0 +1,28 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlankPieceTest {
+    private Piece piece;
+
+    @BeforeEach
+    void setup() {
+        piece = PieceFactory.createBlankPiece();
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTH", "NNE", "EAST", "EES"})
+    @DisplayName("움직일 수 없다.")
+    void mustMoveKnightsDirection_false(Direction direction) {
+        int hopeCount = 1;
+
+        assertFalse(piece.verifyMovePosition(direction, hopeCount));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/KingTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/KingTest.java
@@ -1,0 +1,56 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KingTest {
+
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createKing(Color.WHITE);
+        black = PieceFactory.createKing(Color.BLACK);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTH", "NORTHEAST", "EAST", "SOUTH"})
+    @DisplayName("모든 방향으로만 이동 가능하다.")
+    void mustMoveKingDirection(Direction direction) {
+        int hopeCount = 1;
+
+        assertTrue(white.verifyMovePosition(direction, hopeCount));
+        assertTrue(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTH", "NORTHEAST", "EAST", "SOUTH"})
+    @DisplayName("한 칸만 이동 가능하다.")
+    void mustMoveKingDirection_false(Direction direction) {
+        int hopeCount = 2;
+
+        assertFalse(white.verifyMovePosition(direction, hopeCount));
+        assertFalse(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/KnightTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/KnightTest.java
@@ -1,0 +1,56 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KnightTest {
+
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createKnight(Color.WHITE);
+        black = PieceFactory.createKnight(Color.BLACK);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NNE", "NNW", "EES", "EEN", "SSE"})
+    @DisplayName("나이트 방향으로만 이동 가능하다.")
+    void mustMoveKnightsDirection(Direction direction) {
+        int hopeCount = 1;
+
+        assertTrue(white.verifyMovePosition(direction, hopeCount));
+        assertTrue(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTH", "NORTHEAST", "EAST", "SOUTH"})
+    @DisplayName("나이트 방향으로만 이동 가능하다.")
+    void mustMoveKnightsDirection_false(Direction direction) {
+        int hopeCount = 1;
+
+        assertFalse(white.verifyMovePosition(direction, hopeCount));
+        assertFalse(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/PawnTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/PawnTest.java
@@ -1,0 +1,60 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static softeer2nd.chess.domain.enums.Color.BLACK;
+import static softeer2nd.chess.domain.enums.Color.WHITE;
+
+class PawnTest {
+
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createPawn(WHITE);
+        black = PieceFactory.createPawn(BLACK);
+    }
+
+    @Test
+    @DisplayName("앞으로 방향으로만 이동 가능하다.")
+    void mustMoveWhitePawn() {
+        int hopeCount = 1;
+        Direction north = Direction.NORTH;
+        Direction south = Direction.SOUTH;
+
+        assertTrue(white.verifyMovePosition(north, hopeCount));
+        assertFalse(white.verifyMovePosition(south, hopeCount));
+    }
+
+    @Test
+    @DisplayName("앞으로 방향으로만 이동 가능하다.")
+    void mustMoveBlackPawn() {
+        int hopeCount = 1;
+        Direction north = Direction.NORTH;
+        Direction south = Direction.SOUTH;
+
+        assertTrue(black.verifyMovePosition(north, hopeCount));
+        assertFalse(black.verifyMovePosition(south, hopeCount));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/QueenTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/QueenTest.java
@@ -1,0 +1,58 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Color;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueenTest {
+
+
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createQueen(Color.WHITE);
+        black = PieceFactory.createQueen(Color.BLACK);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NNE", "NNW", "EES", "EEN", "SSE"})
+    @DisplayName("모든 방향으로만 이동 가능하다.")
+    void mustMoveDirection(Direction direction) {
+        int hopeCount = 1;
+
+        assertTrue(white.verifyMovePosition(direction, hopeCount));
+        // 범위 체크는 보드에서 합니다.
+        assertTrue(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NNE", "NNW", "EEN", "SSE"})
+    @DisplayName("나이트 방향으로 이동할 수 없다.")
+    void mustMoveDirection_false(Direction direction) {
+        int hopeCount = 1;
+
+        assertFalse(white.verifyMovePosition(direction, hopeCount));
+        assertFalse(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/domain/pieces/RookTest.java
+++ b/src/test/java/softeer2nd/chess/domain/pieces/RookTest.java
@@ -1,0 +1,57 @@
+package softeer2nd.chess.domain.pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import softeer2nd.chess.domain.enums.Direction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static softeer2nd.chess.domain.enums.Color.BLACK;
+import static softeer2nd.chess.domain.enums.Color.WHITE;
+
+class RookTest {
+
+    private Piece white;
+    private Piece black;
+
+    @BeforeEach
+    void setup() {
+        white = PieceFactory.createRook(WHITE);
+        black = PieceFactory.createRook(BLACK);
+    }
+
+    @ParameterizedTest
+    @DisplayName("상하좌우 방향으로만 이동 가능하다.")
+    @EnumSource(names = {"NORTH", "SOUTH", "EAST", "WEST"})
+    void mustMoveRookDirection(Direction direction) {
+        int hopeCount = 1;
+
+        assertTrue(white.verifyMovePosition(direction, hopeCount));
+        assertTrue(black.verifyMovePosition(direction, hopeCount));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"NORTHWEST", "NORTHEAST", "SOUTHEAST"})
+    @DisplayName("한 칸만 이동 가능하다.")
+    void mustMoveRookDirection_false(Direction direction) {
+        int hopeCount = 2;
+
+        assertFalse(white.verifyMovePosition(direction, hopeCount));
+        assertFalse(black.verifyMovePosition(direction, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("자기 턴에 움직이는가?")
+    void doesPieceMoveInItsTurn() {
+        int whiteTurn = 0;
+        int blackTurn = 1;
+
+        assertTrue(white.isTurn(whiteTurn));
+        assertTrue(black.isTurn(blackTurn));
+
+        assertFalse(white.isTurn(blackTurn));
+        assertFalse(black.isTurn(whiteTurn));
+    }
+}

--- a/src/test/java/softeer2nd/chess/finalTest.java
+++ b/src/test/java/softeer2nd/chess/finalTest.java
@@ -1,0 +1,19 @@
+package softeer2nd.chess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+ class finalTest {
+    private final List<Integer> list =new ArrayList<>(List.of(1,2,3,4,5,6));;
+
+    @Test
+    void test() {
+        list.set(0, 10);
+        assertEquals(list.get(0), 10);
+    } // 참조하는 주소값을 고정.. add, set 도 됨
+}


### PR DESCRIPTION
## 구현 내용
- Board 메소드 쪼개기
- GameController 명령 예외처리
  - move 명령이 아닐 때
  - 좌표 입력이 정규표현식과 다를 때
  - 보드 밖을 넘어가는 명령일 때
-  기물을 이동하는 경로에 다른 기물이 있으면 이동하지 못함
- 폰 공격 대각선 방향으로만 가능
- 나이트는 기물 뛰어넘어서 이동 가능
- 라운드 별로 자신의 기물만 이동 가능
- 킹을 잡았을 때 게임 종료
- Custom Exception 구현

## 고민 사항
- step-7 을 진행하면서 많은 예외들이 생각나서 어떻게 해야 재사용할 수 있을지 고민했다. 그러기 위해선 Piece에 검증 코드들이 추가해야 했는데(나이트인지 폰인지 색깔이 같은지 등등) 인터페이스로 만든 바람에 메소드를 추가하면 구현체 전체를 수정했어야 돼서 getType()을 많이 사용했다. 처음부터 abstract class로 추상화했어야 했다.
- 폰 공격......이 아쉽다. 급하게 구현해서 그런가 마지막에 if문을 남발하였다. 

## 기타
그래도 Piece 관심사 줄이기는 성공한 것 같다.