### PR TITLE
[최윤식] step-7 예외 처리

### DIFF
--- a/src/main/java/softeer2nd/Main.java
+++ b/src/main/java/softeer2nd/Main.java
@@ -11,6 +11,6 @@ public class Main {
                 new ConsoleInputView()
         );
 
-        chessGameController.main();
+        chessGameController.start();
     }
 }

--- a/src/main/java/softeer2nd/controller/ChessGameController.java
+++ b/src/main/java/softeer2nd/controller/ChessGameController.java
@@ -6,6 +6,7 @@ import softeer2nd.domain.chess.ChessGame;
 import softeer2nd.domain.chess.DefaultBoard;
 import softeer2nd.domain.chess.DefaultChessPointCalculator;
 import softeer2nd.domain.chess.DefaultChessView;
+import softeer2nd.domain.chess.Turn;
 import softeer2nd.view.InputView;
 import softeer2nd.view.OutputView;
 
@@ -22,7 +23,8 @@ public class ChessGameController {
         ChessGame chessGame = new ChessGame(
                 new DefaultChessView(),
                 new DefaultChessPointCalculator(),
-                new DefaultBoard()
+                new DefaultBoard(),
+                Turn.WHITE
         );
 
         play(chessGame);
@@ -30,7 +32,7 @@ public class ChessGameController {
 
     private void play(final ChessGame chessGame) {
         try {
-            outputView.printCommandInputGuideLine(values());
+            outputView.printCommandInputGuideLine(chessGame.printTurn(), values());
             String command = inputView.command();
             if (isNotExistsCommand(command)) {
                 throw new IllegalArgumentException("잘못된 커맨드 입력입니다.");

--- a/src/main/java/softeer2nd/controller/ChessGameController.java
+++ b/src/main/java/softeer2nd/controller/ChessGameController.java
@@ -1,5 +1,7 @@
 package softeer2nd.controller;
 
+import static softeer2nd.controller.Command.*;
+
 import softeer2nd.domain.chess.ChessGame;
 import softeer2nd.domain.chess.DefaultBoard;
 import softeer2nd.domain.chess.DefaultChessPointCalculator;
@@ -16,28 +18,36 @@ public class ChessGameController {
         this.inputView = inputView;
     }
 
-    public void main() {
-        ChessGame chessGame = new ChessGame(new DefaultChessView(), new DefaultChessPointCalculator(),
-                new DefaultBoard());
-        while (true) {
-            try {
-                String command = inputView.command();
-                if (Command.isNotExistsCommand(command)) {
-                    throw new IllegalArgumentException("잘못된 커맨드 입력입니다.");
-                }
-                if (Command.isEnd(command)) {
-                    break;
-                }
-                if (Command.isStart(command)) {
-                    chessGame.initialize();
-                }
-                if (Command.isMove(command)) {
-                    chessGame.move(Command.moveSource(command), Command.moveTarget(command));
-                }
-                outputView.print(chessGame.show());
-            } catch (Exception e) {
-                outputView.print(e.getMessage());
+    public void start() {
+        ChessGame chessGame = new ChessGame(
+                new DefaultChessView(),
+                new DefaultChessPointCalculator(),
+                new DefaultBoard()
+        );
+
+        play(chessGame);
+    }
+
+    private void play(final ChessGame chessGame) {
+        try {
+            outputView.printCommandInputGuideLine(values());
+            String command = inputView.command();
+            if (isNotExistsCommand(command)) {
+                throw new IllegalArgumentException("잘못된 커맨드 입력입니다.");
             }
+            if (isEnd(command)) {
+                return;
+            }
+            if (isStart(command)) {
+                chessGame.initialize();
+            }
+            if (isMove(command)) {
+                chessGame.move(moveSource(command), moveTarget(command));
+            }
+            outputView.print(chessGame.show());
+        } catch (Exception e) {
+            outputView.print(e.getMessage());
         }
+        play(chessGame);
     }
 }

--- a/src/main/java/softeer2nd/controller/ChessGameController.java
+++ b/src/main/java/softeer2nd/controller/ChessGameController.java
@@ -17,22 +17,27 @@ public class ChessGameController {
     }
 
     public void main() {
-        ChessGame chessGame = new ChessGame(new DefaultChessView(), new DefaultChessPointCalculator(), new DefaultBoard());
+        ChessGame chessGame = new ChessGame(new DefaultChessView(), new DefaultChessPointCalculator(),
+                new DefaultBoard());
         while (true) {
-            String command = inputView.command();
-            if (Command.isNotExistsCommand(command)) {
-                throw new IllegalArgumentException("잘못된 커맨드 입력입니다.");
+            try {
+                String command = inputView.command();
+                if (Command.isNotExistsCommand(command)) {
+                    throw new IllegalArgumentException("잘못된 커맨드 입력입니다.");
+                }
+                if (Command.isEnd(command)) {
+                    break;
+                }
+                if (Command.isStart(command)) {
+                    chessGame.initialize();
+                }
+                if (Command.isMove(command)) {
+                    chessGame.move(Command.moveSource(command), Command.moveTarget(command));
+                }
+                outputView.print(chessGame.show());
+            } catch (Exception e) {
+                outputView.print(e.getMessage());
             }
-            if (Command.isEnd(command)) {
-                break;
-            }
-            if (Command.isStart(command)) {
-                chessGame.initialize();
-            }
-            if (Command.isMove(command)) {
-                chessGame.move(Command.moveSource(command), Command.moveTarget(command));
-            }
-            outputView.print(chessGame.show());
         }
     }
 }

--- a/src/main/java/softeer2nd/controller/Command.java
+++ b/src/main/java/softeer2nd/controller/Command.java
@@ -43,4 +43,8 @@ public enum Command {
     public static String moveTarget(final String command) {
         return command.split(MOVE_DELIMITER)[MOVE_TARGET_INDEX];
     }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/softeer2nd/domain/chess/Board.java
+++ b/src/main/java/softeer2nd/domain/chess/Board.java
@@ -3,7 +3,6 @@ package softeer2nd.domain.chess;
 import java.util.List;
 import java.util.stream.Collectors;
 import softeer2nd.domain.chess.pieces.Piece;
-import softeer2nd.domain.chess.pieces.Piece.Color;
 import softeer2nd.domain.chess.pieces.Position;
 
 public interface Board {

--- a/src/main/java/softeer2nd/domain/chess/Board.java
+++ b/src/main/java/softeer2nd/domain/chess/Board.java
@@ -10,7 +10,7 @@ public interface Board {
 
     void initialize();
 
-    void move(final String sourcePosition, final String targetPosition);
+    void move(final String sourcePosition, final String targetPosition, final Turn turn);
 
     void addPiece(final String position, final Piece piece);
 

--- a/src/main/java/softeer2nd/domain/chess/ChessGame.java
+++ b/src/main/java/softeer2nd/domain/chess/ChessGame.java
@@ -14,11 +14,18 @@ public class ChessGame {
     private final ChessView chessView;
     private final ChessPointCalculator chessPointCalculator;
     private final Board board;
+    private Turn turn;
 
-    public ChessGame(final ChessView chessView, final ChessPointCalculator chessPointCalculator, final Board board) {
+    public ChessGame(
+            final ChessView chessView,
+            final ChessPointCalculator chessPointCalculator,
+            final Board board,
+            final Turn turn
+    ) {
         this.chessView = chessView;
         this.chessPointCalculator = chessPointCalculator;
         this.board = board;
+        this.turn = turn;
     }
 
     public void initializeEmpty() {
@@ -38,7 +45,8 @@ public class ChessGame {
     }
 
     public void move(final String sourcePosition, final String targetPosition) {
-        board.move(sourcePosition, targetPosition);
+        board.move(sourcePosition, targetPosition, turn);
+        this.turn = turn.end();
     }
 
     public Piece findPiece(final String position) {
@@ -55,5 +63,9 @@ public class ChessGame {
 
     public List<Piece> sortByPoint(final Color color, final PieceComparator pieceComparator) {
         return this.board.sortByPoint(color, pieceComparator);
+    }
+
+    public String printTurn() {
+        return this.turn.name();
     }
 }

--- a/src/main/java/softeer2nd/domain/chess/ChessGame.java
+++ b/src/main/java/softeer2nd/domain/chess/ChessGame.java
@@ -2,7 +2,6 @@ package softeer2nd.domain.chess;
 
 import java.util.List;
 import softeer2nd.domain.chess.pieces.Piece;
-import softeer2nd.domain.chess.pieces.Piece.Color;
 
 public class ChessGame {
     public static final int HEIGHT = 8;

--- a/src/main/java/softeer2nd/domain/chess/ChessPointCalculator.java
+++ b/src/main/java/softeer2nd/domain/chess/ChessPointCalculator.java
@@ -1,7 +1,5 @@
 package softeer2nd.domain.chess;
 
-import softeer2nd.domain.chess.pieces.Piece.Color;
-
 public interface ChessPointCalculator {
     double calculatePoint(final Board board, final Color color);
 }

--- a/src/main/java/softeer2nd/domain/chess/Color.java
+++ b/src/main/java/softeer2nd/domain/chess/Color.java
@@ -1,0 +1,17 @@
+package softeer2nd.domain.chess;
+
+import java.util.Optional;
+
+public enum Color {
+    WHITE, BLACK, NOCOLOR;
+
+    public Optional<Color> getEnemy() {
+        if (this.equals(WHITE)) {
+            return Optional.of(BLACK);
+        }
+        if (this.equals(BLACK)) {
+            return Optional.of(WHITE);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/softeer2nd/domain/chess/DefaultBoard.java
+++ b/src/main/java/softeer2nd/domain/chess/DefaultBoard.java
@@ -38,8 +38,10 @@ public class DefaultBoard implements Board {
     }
 
     @Override
-    public void move(final String sourcePosition, final String targetPosition) {
+    public void move(final String sourcePosition, final String targetPosition, final Turn turn) {
         Piece piece = findPiece(sourcePosition);
+
+        validationTurn(turn, piece);
 
         Position movePosition = new Position(targetPosition);
         this.ranks.get(movePosition.getY())
@@ -48,6 +50,12 @@ public class DefaultBoard implements Board {
         Position originPosition = piece.getPosition();
         this.ranks.get(originPosition.getY())
                 .set(originPosition.getX(), Piece.createBlank(originPosition));
+    }
+
+    private void validationTurn(final Turn turn, final Piece piece) {
+        if (!turn.is(piece.getColor())) {
+            throw new IllegalArgumentException(String.format("지금은 %s 턴입니다.", turn.name()));
+        }
     }
 
     private List<List<Piece>> getPieceList() {

--- a/src/main/java/softeer2nd/domain/chess/DefaultChessPointCalculator.java
+++ b/src/main/java/softeer2nd/domain/chess/DefaultChessPointCalculator.java
@@ -6,7 +6,6 @@ import static softeer2nd.domain.chess.ChessGame.WIDTH;
 import java.util.List;
 import java.util.stream.IntStream;
 import softeer2nd.domain.chess.pieces.Piece;
-import softeer2nd.domain.chess.pieces.Piece.Color;
 
 public class DefaultChessPointCalculator implements ChessPointCalculator {
     private static final double DUPLICATE_FILE_PAWN_POINT = 0.5;

--- a/src/main/java/softeer2nd/domain/chess/Turn.java
+++ b/src/main/java/softeer2nd/domain/chess/Turn.java
@@ -1,0 +1,23 @@
+package softeer2nd.domain.chess;
+
+public enum Turn {
+    WHITE(Color.WHITE),
+    BLACK(Color.BLACK);
+
+    private final Color color;
+
+    Turn(final Color color) {
+        this.color = color;
+    }
+
+    public Turn end() {
+        if (this.equals(WHITE)) {
+            return BLACK;
+        }
+        return WHITE;
+    }
+
+    public boolean is(final Color color) {
+        return this.color.equals(color);
+    }
+}

--- a/src/main/java/softeer2nd/domain/chess/pieces/Bishop.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Bishop.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Bishop extends Piece {
     private static final String REPRESENTATION = "b";

--- a/src/main/java/softeer2nd/domain/chess/pieces/Blank.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Blank.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Blank extends Piece {
     private static final String REPRESENTATION = ".";

--- a/src/main/java/softeer2nd/domain/chess/pieces/King.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/King.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class King extends Piece {
     private static final String REPRESENTATION = "k";

--- a/src/main/java/softeer2nd/domain/chess/pieces/Knight.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Knight.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Knight extends Piece {
     private static final String REPRESENTATION = "n";

--- a/src/main/java/softeer2nd/domain/chess/pieces/Pawn.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Pawn.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Pawn extends Piece {
     private static final String REPRESENTATION = "p";

--- a/src/main/java/softeer2nd/domain/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Piece.java
@@ -4,22 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import softeer2nd.domain.chess.Color;
 
 public abstract class Piece {
-    public enum Color {
-        WHITE, BLACK, NOCOLOR;
-
-        public Optional<Color> getEnemy() {
-            if (this.equals(WHITE)) {
-                return Optional.of(BLACK);
-            }
-            if (this.equals(BLACK)) {
-                return Optional.of(WHITE);
-            }
-            return Optional.empty();
-        }
-    }
-
     private final double point;
     private final String representation;
 

--- a/src/main/java/softeer2nd/domain/chess/pieces/Queen.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Queen.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Queen extends Piece {
     private static final String REPRESENTATION = "q";

--- a/src/main/java/softeer2nd/domain/chess/pieces/Rook.java
+++ b/src/main/java/softeer2nd/domain/chess/pieces/Rook.java
@@ -2,6 +2,7 @@ package softeer2nd.domain.chess.pieces;
 
 import java.util.ArrayList;
 import java.util.List;
+import softeer2nd.domain.chess.Color;
 
 public class Rook extends Piece {
     private static final String REPRESENTATION = "r";

--- a/src/main/java/softeer2nd/view/ConsoleOutputView.java
+++ b/src/main/java/softeer2nd/view/ConsoleOutputView.java
@@ -1,8 +1,19 @@
 package softeer2nd.view;
 
+import softeer2nd.controller.Command;
+
 public class ConsoleOutputView implements OutputView {
     @Override
     public void print(final String text) {
         System.out.println(text);
+    }
+
+    @Override
+    public void printCommandInputGuideLine(final Command[] values) {
+        print("커맨드를 입력해주세요.");
+        for (int i = 0; i < values.length; i++) {
+            Command command = values[i];
+            print(String.format("%s. %s : %s", i + 1, command.name(), command.getValue()));
+        }
     }
 }

--- a/src/main/java/softeer2nd/view/ConsoleOutputView.java
+++ b/src/main/java/softeer2nd/view/ConsoleOutputView.java
@@ -9,8 +9,9 @@ public class ConsoleOutputView implements OutputView {
     }
 
     @Override
-    public void printCommandInputGuideLine(final Command[] values) {
+    public void printCommandInputGuideLine(final String turn, final Command[] values) {
         print("커맨드를 입력해주세요.");
+        print(String.format("현재 %s 입니다.", turn));
         for (int i = 0; i < values.length; i++) {
             Command command = values[i];
             print(String.format("%s. %s : %s", i + 1, command.name(), command.getValue()));

--- a/src/main/java/softeer2nd/view/OutputView.java
+++ b/src/main/java/softeer2nd/view/OutputView.java
@@ -5,5 +5,5 @@ import softeer2nd.controller.Command;
 public interface OutputView {
     void print(final String text);
 
-    void printCommandInputGuideLine(Command[] values);
+    void printCommandInputGuideLine(final String turn, Command[] values);
 }

--- a/src/main/java/softeer2nd/view/OutputView.java
+++ b/src/main/java/softeer2nd/view/OutputView.java
@@ -1,5 +1,9 @@
 package softeer2nd.view;
 
+import softeer2nd.controller.Command;
+
 public interface OutputView {
     void print(final String text);
+
+    void printCommandInputGuideLine(Command[] values);
 }

--- a/src/test/java/softeer2nd/domain/chess/ChessGameTest.java
+++ b/src/test/java/softeer2nd/domain/chess/ChessGameTest.java
@@ -23,7 +23,8 @@ public class ChessGameTest {
 
     @BeforeEach
     void setUp() {
-        this.chessGame = new ChessGame(new DefaultChessView(), new DefaultChessPointCalculator(), new DefaultBoard());
+        this.chessGame = new ChessGame(new DefaultChessView(), new DefaultChessPointCalculator(), new DefaultBoard(),
+                Turn.WHITE);
         this.position = new Position("a1");
     }
 
@@ -201,6 +202,7 @@ public class ChessGameTest {
                 setWhitePawn("c6");
                 String sourcePosition = "b7";
 
+                chessGame.move("a2", "a3");
                 chessGame.move(sourcePosition, targetPosition);
 
                 assertAll(
@@ -235,12 +237,12 @@ public class ChessGameTest {
             void move(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackBishop(new Position(originPosition)));
+                chessGame.addPiece(originPosition, Piece.createWhiteBishop(new Position(originPosition)));
 
                 chessGame.move(originPosition, targetPosition);
 
                 assertEquals(
-                        Piece.createBlackBishop(new Position(targetPosition)), chessGame.findPiece(targetPosition)
+                        Piece.createWhiteBishop(new Position(targetPosition)), chessGame.findPiece(targetPosition)
                 );
             }
 
@@ -314,12 +316,12 @@ public class ChessGameTest {
             void move(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackRook(new Position(originPosition)));
+                chessGame.addPiece(originPosition, Piece.createWhiteRook(new Position(originPosition)));
 
                 chessGame.move(originPosition, targetPosition);
 
                 assertEquals(
-                        Piece.createBlackRook(new Position(targetPosition)), chessGame.findPiece(targetPosition)
+                        Piece.createWhiteRook(new Position(targetPosition)), chessGame.findPiece(targetPosition)
                 );
             }
 
@@ -329,7 +331,7 @@ public class ChessGameTest {
             void moveDiagonal(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackRook(new Position(originPosition)));
+                chessGame.addPiece(originPosition, Piece.createWhiteRook(new Position(originPosition)));
 
                 Assertions.assertThatThrownBy(() -> chessGame.move(originPosition, targetPosition))
                         .isInstanceOf(IllegalArgumentException.class);
@@ -341,11 +343,11 @@ public class ChessGameTest {
             void moveEnemy(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackRook(new Position(originPosition)));
-                setWhitePawn("d6");
-                setWhitePawn("d2");
-                setWhitePawn("c4");
-                setWhitePawn("e4");
+                chessGame.addPiece(originPosition, Piece.createWhiteRook(new Position(originPosition)));
+                setBlackPawn("d6");
+                setBlackPawn("d2");
+                setBlackPawn("c4");
+                setBlackPawn("e4");
 
                 Assertions.assertThatThrownBy(() -> chessGame.move(originPosition, targetPosition))
                         .isInstanceOf(IllegalArgumentException.class);
@@ -357,11 +359,11 @@ public class ChessGameTest {
             void moveAlly(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackRook(new Position(originPosition)));
-                setBlackPawn("d7");
-                setBlackPawn("d1");
-                setBlackPawn("b4");
-                setBlackPawn("e4");
+                chessGame.addPiece(originPosition, Piece.createWhiteRook(new Position(originPosition)));
+                setWhitePawn("d7");
+                setWhitePawn("d1");
+                setWhitePawn("b4");
+                setWhitePawn("e4");
 
                 Assertions.assertThatThrownBy(() -> chessGame.move(originPosition, targetPosition))
                         .isInstanceOf(IllegalArgumentException.class);
@@ -435,11 +437,11 @@ public class ChessGameTest {
             void move(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackKing(new Position(originPosition)));
+                chessGame.addPiece(originPosition, Piece.createWhiteKing(new Position(originPosition)));
 
                 chessGame.move(originPosition, targetPosition);
 
-                assertEquals(Piece.createBlackKing(new Position(targetPosition)), chessGame.findPiece(targetPosition));
+                assertEquals(Piece.createWhiteKing(new Position(targetPosition)), chessGame.findPiece(targetPosition));
             }
 
             @DisplayName("킹은 아군의 위치까지 이동할 수 있다.")
@@ -468,15 +470,15 @@ public class ChessGameTest {
             void moveEnemy(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackKing(new Position(originPosition)));
-                setWhitePawn("c5");
-                setWhitePawn("d5");
-                setWhitePawn("e5");
-                setWhitePawn("c4");
-                setWhitePawn("c3");
-                setWhitePawn("d3");
-                setWhitePawn("e3");
-                setWhitePawn("e4");
+                chessGame.addPiece(originPosition, Piece.createWhiteKing(new Position(originPosition)));
+                setBlackPawn("c5");
+                setBlackPawn("d5");
+                setBlackPawn("e5");
+                setBlackPawn("c4");
+                setBlackPawn("c3");
+                setBlackPawn("d3");
+                setBlackPawn("e3");
+                setBlackPawn("e4");
 
                 Assertions.assertThatCode(() -> chessGame.move(originPosition, targetPosition))
                         .doesNotThrowAnyException();
@@ -492,7 +494,7 @@ public class ChessGameTest {
             void move(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackKnight(new Position(originPosition)));
+                chessGame.addPiece(originPosition, Piece.createWhiteKnight(new Position(originPosition)));
                 setBlackPawn("c5");
                 setBlackPawn("d5");
                 setBlackPawn("e5");
@@ -504,7 +506,8 @@ public class ChessGameTest {
 
                 chessGame.move(originPosition, targetPosition);
 
-                assertEquals(Piece.createBlackKnight(new Position(targetPosition)), chessGame.findPiece(targetPosition));
+                assertEquals(Piece.createWhiteKnight(new Position(targetPosition)),
+                        chessGame.findPiece(targetPosition));
             }
 
             @DisplayName("나이트가 이동하려는 곳에 아군이 있으면 예외처리한다.")
@@ -513,15 +516,15 @@ public class ChessGameTest {
             void moveAlly(String targetPosition) {
                 chessGame.initializeEmpty();
                 String originPosition = "d4";
-                chessGame.addPiece(originPosition, Piece.createBlackKnight(new Position(originPosition)));
-                setBlackPawn("c6");
-                setBlackPawn("e6");
-                setBlackPawn("f5");
-                setBlackPawn("f3");
-                setBlackPawn("e2");
-                setBlackPawn("c2");
-                setBlackPawn("b3");
-                setBlackPawn("b5");
+                chessGame.addPiece(originPosition, Piece.createWhiteKnight(new Position(originPosition)));
+                setWhitePawn("c6");
+                setWhitePawn("e6");
+                setWhitePawn("f5");
+                setWhitePawn("f3");
+                setWhitePawn("e2");
+                setWhitePawn("c2");
+                setWhitePawn("b3");
+                setWhitePawn("b5");
 
                 Assertions.assertThatThrownBy(() -> chessGame.move(originPosition, targetPosition))
                         .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/softeer2nd/domain/chess/ChessGameTest.java
+++ b/src/test/java/softeer2nd/domain/chess/ChessGameTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import softeer2nd.domain.chess.pieces.Piece;
-import softeer2nd.domain.chess.pieces.Piece.Color;
 import softeer2nd.domain.chess.pieces.Position;
 
 @DisplayName("체스 판 관련 기능")

--- a/src/test/java/softeer2nd/domain/chess/pieces/BishopTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/BishopTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("비숍 관련 기능")
 class BishopTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/BlankTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/BlankTest.java
@@ -2,13 +2,13 @@ package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("공백 관련 기능")
 class BlankTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/KingTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/KingTest.java
@@ -1,12 +1,12 @@
 package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("킹 관련 기능")
 class KingTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/KnightTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/KnightTest.java
@@ -1,12 +1,12 @@
 package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("나이트 관련 기능")
 class KnightTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/PawnTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/PawnTest.java
@@ -1,12 +1,12 @@
 package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("폰 관련 기능")
 class PawnTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/PieceTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/PieceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("기물 관련 기능")
 public class PieceTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/QueenTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/QueenTest.java
@@ -1,12 +1,12 @@
 package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("퀸 관련 기능")
 class QueenTest {

--- a/src/test/java/softeer2nd/domain/chess/pieces/RookTest.java
+++ b/src/test/java/softeer2nd/domain/chess/pieces/RookTest.java
@@ -1,12 +1,12 @@
 package softeer2nd.domain.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import softeer2nd.domain.chess.pieces.Piece.Color;
+import softeer2nd.domain.chess.Color;
 
 @DisplayName("룩 관련 기능")
 class RookTest {


### PR DESCRIPTION
## 구현 내용
- 기물 위치 예외 처리

- 기물이 유효하지 않은 위치로 이동
  - 이동하려는 위치가 기물의 현재 위치와 같다.
  - 이동하려는 위치가 기물의 이동 규칙을 따르지 않는다.
  - 이동하려는 위치가 유효한 위치이기는 하나 같은 편의 기물이 이미 존재한다.

- 다른 편의 기물을 이동하려고 할 때
  - 현재 기물을 두어야 하는 사람이 기물을 두지 않고 상대편 기물을 이동하려고 하는 경우 예외 처리해야 한다.
  - 흰색 편이 기물을 두어야 하는 순서인데 검은 색 기물을 이동하려고 하는 예외 처리한다.

## 고민 사항
- 해당 미션에서는 예외 처리 기능을 구현할 때, 이미 이전에 예외 처리를 고려하여 준비해둔 상태였기 때문에 원활하게 진행되었습니다. 다만, 예외 처리 시에 커스텀 예외와 기본 자바 예외를 고민하였으나, 이번 미션에서는 기본 자바 예외를 사용하기로 결정했습니다. 이유는 예외 메시지를 통해 충분히 의미를 전달할 수 있다고 판단했기 때문입니다. 그 결과, 모든 예외 처리에서 기본 자바 예외를 사용하여 깔끔하게 처리할 수 있었습니다.

- 이동한 기물의 위치를 완료한 후에 예외가 발생하는 경우, 체스 판의 원자성을 보장할 수 없는 문제가 발생할 수 있습니다. 이를 해결하기 위해, 최대한 원자성을 보장하기 위한 방법으로 로직을 작성했습니다. 기물 이동을 먼저 채운 후에 빈칸을 채우도록 처리하였습니다. 이 방식을 통해 트랜잭션 없이도 체스 판이 최대한 문제 없이 유지될 수 있도록 구현하였습니다. 이로써 체스 판의 일관성과 정합성을 유지할 수 있게 되었습니다.

## 기타
- 체스 게임 미션 끝 😁